### PR TITLE
Improve FATF tier classification for judiciary roles #3

### DIFF
--- a/africapep/pipeline/classifier.py
+++ b/africapep/pipeline/classifier.py
@@ -24,7 +24,9 @@ TIER_1_TITLES = [
     # Judicial heads
     "chief justice", "deputy chief justice",
     "justice of the supreme court", "supreme court justice",
+    "constitutional court judge", "justice of the constitutional court",
     "president of the court of appeal",
+    "président de la cour suprême", "juge constitutionnel",
     # Central bank
     "governor of the central bank", "central bank governor",
     "governor of the bank of ghana", "governor of the reserve bank",
@@ -70,6 +72,7 @@ TIER_2_TITLES = [
     "high court judge", "judge of the high court",
     "appeal court judge", "judge of the court of appeal",
     "judge of the federal high court",
+    "juge d'appel", "juge de la haute cour",
     # Ambassadors
     "ambassador", "high commissioner",
     "permanent representative",
@@ -112,7 +115,7 @@ TIER_3_TITLES = [
     "municipal chief executive", "district chief executive",
     "local government chairman", "local government chair",
     "councillor", "council member",
-    "magistrate", "district judge",
+    "magistrate", "district judge", "magistrat",
     "deputy minister", "assistant minister",
     "acting minister",
     "permanent secretary", "deputy director",

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -114,6 +114,14 @@ class TestClassifier:
 
         assert classify_pep_tier("Chief Justice") == 1
         assert classify_pep_tier("Justice of the Supreme Court") == 1
+        assert classify_pep_tier("Constitutional Court Judge") == 1
+        assert classify_pep_tier("Président de la Cour Suprême") == 1
+
+    def test_judiciary_french_tiers(self):
+        from africapep.pipeline.classifier import classify_pep_tier
+
+        assert classify_pep_tier("Juge d'appel") == 2
+        assert classify_pep_tier("Magistrat") == 3
 
     def test_tier_1_central_bank(self):
         from africapep.pipeline.classifier import classify_pep_tier

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -155,7 +155,7 @@ def test_wikidata_scraper_scrape_with_mock():
     assert records[1].full_name == "Godswill Akpabio"
     assert records[1].extra_fields["start_date"] == "2023-06-13"
     assert records[1].extra_fields["is_current"] is True
-    
+
     # Verify extraction of Date of Birth (P569) from the mock SPARQL response
     assert records[1].extra_fields["date_of_birth"] == "1962-12-09"
 


### PR DESCRIPTION
### Summary
This PR expands the FATF tier classifier to better categorize judiciary positions across African countries, including support for French legislative terms.

### Technical Details
- **Judiciary Refinement**: Added "Constitutional Court Judge" and related roles to Tier 1.
- **French Support**: Added French equivalents such as "Président de la Cour Suprême", "Juge d'appel", and "Magistrat" to their respective tiers.

Fixes #3

Thank you!
