### PR TITLE
feat: expand Wikidata PEP catchment for low-coverage countries

### DIFF
--- a/africapep/scraper/spiders/wikidata_scraper.py
+++ b/africapep/scraper/spiders/wikidata_scraper.py
@@ -24,6 +24,22 @@ log = structlog.get_logger(__name__)
 
 SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
 
+# Label language priority chain. Latin scripts first (so searchable names win),
+# native scripts only as a last resort. This recovers officials of Portuguese
+# (Guinea-Bissau, Sao Tome), French/Arabic (Djibouti) and Tigrinya (Eritrea)
+# countries who lack an English label and were previously dropped as blank.
+LABEL_LANGS = "en,pt,fr,es,sw,ar,ti"
+
+# Wikidata QID for "public office". Used to keep the citizenship-based catchment
+# within the existing PEP seniority definition: a citizen only qualifies if the
+# position they hold is (a subclass of) a public office, excluding sports,
+# academic and other non-political P39 positions.
+PUBLIC_OFFICE_QID = "Q294414"
+
+# Cap on the number of position QIDs sent in a single VALUES clause when
+# classifying positions by office class (keeps each follow-up query small/fast).
+_OFFICE_CLASS_BATCH = 200
+
 # Wikidata QIDs for African countries, keyed by ISO 3166-1 alpha-2
 COUNTRY_QIDS: Dict[str, str] = {
     "DZ": "Q262", "AO": "Q916", "BJ": "Q962", "BW": "Q963",
@@ -78,19 +94,30 @@ SELECT DISTINCT ?person ?personLabel ?positionLabel ?start ?end
   OPTIONAL {{ ?person wdt:P570 ?dod }}
   OPTIONAL {{ ?person wdt:P102 ?party }}
   OPTIONAL {{ ?person wdt:P27 ?nationality }}
-  SERVICE wikibase:label {{ bd:serviceParam wikibase:language "en" }}
+  SERVICE wikibase:label {{ bd:serviceParam wikibase:language "{LABEL_LANGS}" }}
 }}
 ORDER BY ?personLabel
 LIMIT 5000
 """
 
 
-def _build_query(country_qid: str, since: Optional[str] = None) -> str:
-    """Build SPARQL query to fetch politicians for a country.
+def _modified_filter(since: Optional[str]) -> str:
+    """Build the optional incremental ``schema:dateModified`` filter clause."""
+    if not since:
+        return ""
+    return (
+        f'  ?person schema:dateModified ?modified .\n'
+        f'  FILTER(?modified >= "{since}T00:00:00Z"^^xsd:dateTime)\n'
+    )
 
-    Returns people who hold/held positions (P39) in institutions
-    tied to the given country (P17). Includes position start/end dates,
-    date of birth (P569), date of death (P570), and party affiliation (P102).
+
+def _build_query(country_qid: str, since: Optional[str] = None) -> str:
+    """Build SPARQL query for politicians whose POSITION is tied to a country.
+
+    Branch A of the catchment: people who hold/held a position (P39) whose
+    ``country (P17)`` is the given country. This is the original, proven query
+    and is kept as a standalone request so that the broader (and heavier)
+    branches can never regress coverage below this baseline if they time out.
 
     Args:
         country_qid: Wikidata QID for the country.
@@ -99,12 +126,7 @@ def _build_query(country_qid: str, since: Optional[str] = None) -> str:
             Wikidata revision timestamp (``schema:dateModified``) is after
             this date, enabling incremental scraping.
     """
-    modified_filter = ""
-    if since:
-        modified_filter = (
-            f'  ?person schema:dateModified ?modified .\n'
-            f'  FILTER(?modified >= "{since}T00:00:00Z"^^xsd:dateTime)\n'
-        )
+    modified_filter = _modified_filter(since)
     return f"""
 SELECT DISTINCT ?person ?personLabel ?positionLabel ?institutionLabel
        ?start ?end ?dob ?dod ?partyLabel WHERE {{
@@ -120,10 +142,91 @@ SELECT DISTINCT ?person ?personLabel ?positionLabel ?institutionLabel
   OPTIONAL {{ ?person wdt:P569 ?dob }}
   OPTIONAL {{ ?person wdt:P570 ?dod }}
   OPTIONAL {{ ?person wdt:P102 ?party }}
-  SERVICE wikibase:label {{ bd:serviceParam wikibase:language "en" }}
+  SERVICE wikibase:label {{ bd:serviceParam wikibase:language "{LABEL_LANGS}" }}
 }}
 ORDER BY ?personLabel
 LIMIT 10000
+"""
+
+
+def _build_jurisdiction_query(country_qid: str, since: Optional[str] = None) -> str:
+    """Build SPARQL query for politicians whose POSITION applies to a country.
+
+    Branch B of the catchment: many political positions are linked to their
+    country via ``applies to jurisdiction (P1001)`` rather than ``country
+    (P17)`` -- especially in smaller and non-anglophone countries. This branch
+    captures those, which the original P17-only query missed entirely.
+    """
+    modified_filter = _modified_filter(since)
+    return f"""
+SELECT DISTINCT ?person ?personLabel ?positionLabel ?institutionLabel
+       ?start ?end ?dob ?dod ?partyLabel WHERE {{
+  ?person wdt:P39 ?position .
+  ?position wdt:P1001 wd:{country_qid} .
+{modified_filter}  OPTIONAL {{
+    ?person p:P39 ?stmt .
+    ?stmt ps:P39 ?position .
+    OPTIONAL {{ ?stmt pq:P580 ?start }}
+    OPTIONAL {{ ?stmt pq:P582 ?end }}
+  }}
+  OPTIONAL {{ ?position wdt:P361 ?institution }}
+  OPTIONAL {{ ?person wdt:P569 ?dob }}
+  OPTIONAL {{ ?person wdt:P570 ?dod }}
+  OPTIONAL {{ ?person wdt:P102 ?party }}
+  SERVICE wikibase:label {{ bd:serviceParam wikibase:language "{LABEL_LANGS}" }}
+}}
+ORDER BY ?personLabel
+LIMIT 10000
+"""
+
+
+def _build_citizenship_query(country_qid: str, since: Optional[str] = None) -> str:
+    """Build SPARQL query for citizens of a country who hold any position.
+
+    Branch C (step 1 of 2): candidates are people who are a ``citizen (P27)``
+    of the country and hold any position (P39). This catches officials whose
+    position carries neither P17 nor P1001. It is intentionally broad -- the
+    ``?position`` QID is returned so the caller can keep only those positions
+    that are public offices (see :func:`_build_office_class_filter`), preserving
+    the existing PEP seniority definition.
+    """
+    modified_filter = _modified_filter(since)
+    return f"""
+SELECT DISTINCT ?person ?personLabel ?position ?positionLabel ?institutionLabel
+       ?start ?end ?dob ?dod ?partyLabel WHERE {{
+  ?person wdt:P27 wd:{country_qid} ;
+          wdt:P39 ?position .
+{modified_filter}  OPTIONAL {{
+    ?person p:P39 ?stmt .
+    ?stmt ps:P39 ?position .
+    OPTIONAL {{ ?stmt pq:P580 ?start }}
+    OPTIONAL {{ ?stmt pq:P582 ?end }}
+  }}
+  OPTIONAL {{ ?position wdt:P361 ?institution }}
+  OPTIONAL {{ ?person wdt:P569 ?dob }}
+  OPTIONAL {{ ?person wdt:P570 ?dod }}
+  OPTIONAL {{ ?person wdt:P102 ?party }}
+  SERVICE wikibase:label {{ bd:serviceParam wikibase:language "{LABEL_LANGS}" }}
+}}
+ORDER BY ?personLabel
+LIMIT 10000
+"""
+
+
+def _build_office_class_filter(position_qids: List[str]) -> str:
+    """Build SPARQL query returning which given positions are public offices.
+
+    Branch C (step 2 of 2): given a bounded set of position QIDs, return the
+    subset that are a subclass (P279*) of public office. Run over a small
+    ``VALUES`` set, this avoids the unbounded subclass walk that would otherwise
+    exceed the SPARQL endpoint timeout.
+    """
+    values = " ".join(f"wd:{qid}" for qid in position_qids)
+    return f"""
+SELECT ?position WHERE {{
+  VALUES ?position {{ {values} }}
+  ?position wdt:P279* wd:{PUBLIC_OFFICE_QID} .
+}}
 """
 
 
@@ -164,84 +267,172 @@ class WikidataScraper(BaseScraper):
         )
         return records
 
-    def _query_sparql(self) -> List[RawPersonRecord]:
-        """Execute SPARQL query and parse results into records."""
-        query = _build_query(self._country_qid, since=self.since)
-        now = datetime.now(timezone.utc)
+    def _run_query(self, query: str) -> dict:
+        """Send a SPARQL query and return the parsed JSON response.
 
-        # Use BaseScraper._get() for retry logic and rate limiting
+        Uses BaseScraper._get() for retry logic and polite rate limiting.
+        """
         encoded_params = requests.compat.urlencode(  # type: ignore[attr-defined]
             {"query": query, "format": "json"}
         )
         url = f"{SPARQL_ENDPOINT}?{encoded_params}"
         self.session.headers["Accept"] = "application/json"
         resp = self._get(url)
-        data = resp.json()
+        return resp.json()
 
+    def _query_sparql(self) -> List[RawPersonRecord]:
+        """Execute the multi-branch catchment and merge results.
+
+        Three independent branches are queried and merged, deduplicated by
+        (name, position). Each branch is isolated: if a broader branch fails
+        or times out, the others still contribute, so coverage never regresses
+        below the original P17 baseline (Branch A).
+        """
+        now = datetime.now(timezone.utc)
         records: List[RawPersonRecord] = []
         seen: set = set()
 
-        for binding in data.get("results", {}).get("bindings", []):
-            name = binding.get("personLabel", {}).get("value", "")
-            position = binding.get("positionLabel", {}).get("value", "")
-            institution = binding.get("institutionLabel", {}).get("value", "")
+        def absorb(bindings: list) -> None:
+            for binding in bindings:
+                record = self._binding_to_record(binding, now, seen)
+                if record is not None:
+                    records.append(record)
 
-            # Extract Wikidata QID from the person URI
-            person_uri = binding.get("person", {}).get("value", "")
-            wikidata_qid = person_uri.split("/")[-1] if person_uri else ""
-
-            # Skip blank or QID-only labels (unresolved entities)
-            if not name or name.startswith("Q") or not position:
-                continue
-
-            # Deduplicate by name+position
-            key = (name.lower(), position.lower())
-            if key in seen:
-                continue
-            seen.add(key)
-
-            # Parse dates
-            start_date = _parse_date(binding.get("start", {}).get("value"))
-            end_date = _parse_date(binding.get("end", {}).get("value"))
-            date_of_birth = _parse_date(binding.get("dob", {}).get("value"))
-            date_of_death = _parse_date(binding.get("dod", {}).get("value"))
-            party = binding.get("partyLabel", {}).get("value", "")
-            # Skip QID-only party labels
-            if party.startswith("Q"):
-                party = ""
-
-            # Determine is_current: not current if position has ended,
-            # or if the person has died (historical figures)
-            is_current = _determine_is_current(
-                end_date=end_date,
-                date_of_death=date_of_death,
-                start_date=start_date,
-            )
-
-            records.append(
-                RawPersonRecord(
-                    full_name=name,
-                    title=position,
-                    institution=institution or position,
-                    country_code=self.country_code,
-                    source_url=f"https://www.wikidata.org/wiki/{self._country_qid}",
-                    source_type="WIKIDATA",
-                    raw_text=f"{name} - {position}",
-                    scraped_at=now,
-                    extra_fields={
-                        "start_date": start_date,
-                        "end_date": end_date,
-                        "is_current": is_current,
-                        "date_of_birth": date_of_birth,
-                        "date_of_death": date_of_death,
-                        "party": party,
-                        "wikidata_qid": wikidata_qid,
-                        "wikidata_country_qid": self._country_qid,
-                    },
+        # Branch A (P17) and Branch B (P1001): position tied to the country.
+        for label, builder in (
+            ("p17", _build_query),
+            ("p1001", _build_jurisdiction_query),
+        ):
+            try:
+                data = self._run_query(builder(self._country_qid, since=self.since))
+                absorb(data.get("results", {}).get("bindings", []))
+            except Exception as exc:  # noqa: BLE001 - isolate per-branch failures
+                log.error(
+                    "wikidata.branch.failed",
+                    country=self.country_code,
+                    branch=label,
+                    error=str(exc),
                 )
+
+        # Branch C (citizenship + public office): two-step to stay under the
+        # SPARQL timeout. Fetch citizen candidates, then keep only those whose
+        # position is a public office.
+        try:
+            cdata = self._run_query(
+                _build_citizenship_query(self._country_qid, since=self.since)
+            )
+            cbindings = cdata.get("results", {}).get("bindings", [])
+            candidate_qids = {
+                _qid_from_uri(b.get("position", {}).get("value", ""))
+                for b in cbindings
+            }
+            candidate_qids.discard("")
+            office_qids = self._fetch_office_class_qids(candidate_qids)
+            kept = [
+                b
+                for b in cbindings
+                if _qid_from_uri(b.get("position", {}).get("value", "")) in office_qids
+            ]
+            absorb(kept)
+        except Exception as exc:  # noqa: BLE001 - isolate per-branch failures
+            log.error(
+                "wikidata.branch.failed",
+                country=self.country_code,
+                branch="citizenship",
+                error=str(exc),
             )
 
         return records
+
+    def _fetch_office_class_qids(self, position_qids: set) -> set:
+        """Return the subset of position QIDs that are public offices.
+
+        Batches the lookup so each follow-up query carries a small VALUES set.
+        """
+        office: set = set()
+        qids = [q for q in position_qids if q]
+        for i in range(0, len(qids), _OFFICE_CLASS_BATCH):
+            batch = qids[i : i + _OFFICE_CLASS_BATCH]
+            try:
+                data = self._run_query(_build_office_class_filter(batch))
+            except Exception as exc:  # noqa: BLE001 - degrade gracefully
+                log.error(
+                    "wikidata.officeclass.failed",
+                    country=self.country_code,
+                    batch_size=len(batch),
+                    error=str(exc),
+                )
+                continue
+            for b in data.get("results", {}).get("bindings", []):
+                qid = _qid_from_uri(b.get("position", {}).get("value", ""))
+                if qid:
+                    office.add(qid)
+        return office
+
+    def _binding_to_record(
+        self, binding: dict, now: datetime, seen: set
+    ) -> Optional[RawPersonRecord]:
+        """Convert one SPARQL binding to a record, or None if invalid/duplicate.
+
+        ``seen`` is shared across branches so the same (name, position) pulled
+        in by more than one branch is only emitted once.
+        """
+        name = binding.get("personLabel", {}).get("value", "")
+        position = binding.get("positionLabel", {}).get("value", "")
+        institution = binding.get("institutionLabel", {}).get("value", "")
+
+        # Skip blank or QID-only labels (unresolved entities)
+        if not name or name.startswith("Q") or not position:
+            return None
+
+        # Deduplicate by name+position (shared across all branches)
+        key = (name.lower(), position.lower())
+        if key in seen:
+            return None
+        seen.add(key)
+
+        person_uri = binding.get("person", {}).get("value", "")
+        wikidata_qid = _qid_from_uri(person_uri)
+
+        start_date = _parse_date(binding.get("start", {}).get("value"))
+        end_date = _parse_date(binding.get("end", {}).get("value"))
+        date_of_birth = _parse_date(binding.get("dob", {}).get("value"))
+        date_of_death = _parse_date(binding.get("dod", {}).get("value"))
+        party = binding.get("partyLabel", {}).get("value", "")
+        if party.startswith("Q"):
+            party = ""
+
+        is_current = _determine_is_current(
+            end_date=end_date,
+            date_of_death=date_of_death,
+            start_date=start_date,
+        )
+
+        return RawPersonRecord(
+            full_name=name,
+            title=position,
+            institution=institution or position,
+            country_code=self.country_code,
+            source_url=f"https://www.wikidata.org/wiki/{self._country_qid}",
+            source_type="WIKIDATA",
+            raw_text=f"{name} - {position}",
+            scraped_at=now,
+            extra_fields={
+                "start_date": start_date,
+                "end_date": end_date,
+                "is_current": is_current,
+                "date_of_birth": date_of_birth,
+                "date_of_death": date_of_death,
+                "party": party,
+                "wikidata_qid": wikidata_qid,
+                "wikidata_country_qid": self._country_qid,
+            },
+        )
+
+def _qid_from_uri(uri: str) -> str:
+    """Extract the trailing Wikidata QID from an entity URI ("" if none)."""
+    return uri.split("/")[-1] if uri else ""
+
 
 def _parse_date(value: Optional[str]) -> Optional[str]:
     """Parse Wikidata date string to ISO format."""
@@ -344,7 +535,7 @@ SELECT DISTINCT ?person ?personLabel ?relatedLabel ?relType WHERE {{
     ?person wdt:P3373 ?related .
     BIND("SIBLING" AS ?relType)
   }}
-  SERVICE wikibase:label {{ bd:serviceParam wikibase:language "en" }}
+  SERVICE wikibase:label {{ bd:serviceParam wikibase:language "{LABEL_LANGS}" }}
 }}
 ORDER BY ?personLabel
 LIMIT 10000

--- a/scripts/measure_coverage.py
+++ b/scripts/measure_coverage.py
@@ -1,0 +1,125 @@
+"""Measure Wikidata PEP coverage lift per country.
+
+Compares the *baseline* catchment (positions tied to a country via P17 only --
+the original scraper behaviour) against the *expanded* catchment (P17, plus
+applies-to-jurisdiction P1001, plus citizens holding a public office) for one
+or more countries. Reports distinct-principal counts and the percentage lift.
+
+This queries the live Wikidata SPARQL endpoint with COUNT(DISTINCT ?person),
+so it measures the reachable ceiling of distinct office-holders -- not relatives
+or associates, which the pipeline adds downstream.
+
+Usage:
+    python -m scripts.measure_coverage                # the 6 low-coverage tail
+    python -m scripts.measure_coverage GW ST DJ       # specific countries
+    python -m scripts.measure_coverage --all          # all 54 countries
+
+Note: the expanded query walks position subclasses (P279*) and can take 30-120s
+per country; be patient and polite. Run sparingly.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+import urllib.parse
+import urllib.request
+import json
+from typing import Optional
+
+# Allow running both as ``python -m scripts.measure_coverage`` and directly.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from africapep.scraper.spiders.wikidata_scraper import (
+    COUNTRY_QIDS,
+    PUBLIC_OFFICE_QID,
+)
+
+SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
+USER_AGENT = (
+    "AfricaPEP-coverage/1.0 "
+    "(https://github.com/PatrickAttankurugu/AfricaPEP; measure_coverage.py)"
+)
+
+# The six lowest-coverage countries (default target set).
+DEFAULT_COUNTRIES = ["GW", "ST", "DJ", "LS", "SC", "ER"]
+
+
+def _baseline_where(qid: str) -> str:
+    """Distinct people whose position is tied to the country via P17 (original)."""
+    return f"?x wdt:P39 ?p . ?p wdt:P17 wd:{qid}"
+
+
+def _expanded_where(qid: str) -> str:
+    """Distinct people reachable via P17, P1001, or citizen + public office."""
+    return (
+        f"{{ ?x wdt:P39 ?p . {{ ?p wdt:P17 wd:{qid} }} "
+        f"UNION {{ ?p wdt:P1001 wd:{qid} }} }} "
+        f"UNION {{ ?x wdt:P27 wd:{qid} ; wdt:P39 ?p . "
+        f"?p wdt:P279* wd:{PUBLIC_OFFICE_QID} }}"
+    )
+
+
+def _run_count(where: str, tries: int = 4) -> Optional[int]:
+    """Run a COUNT(DISTINCT ?x) query, retrying on transient errors."""
+    query = f"SELECT (COUNT(DISTINCT ?x) AS ?c) WHERE {{ {where} }}"
+    url = SPARQL_ENDPOINT + "?" + urllib.parse.urlencode({"query": query})
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/sparql-results+json",
+            "User-Agent": USER_AGENT,
+        },
+    )
+    for attempt in range(tries):
+        try:
+            with urllib.request.urlopen(req, timeout=180) as resp:
+                data = json.load(resp)
+            return int(data["results"]["bindings"][0]["c"]["value"])
+        except Exception as exc:  # noqa: BLE001
+            if attempt == tries - 1:
+                print(f"    ! query failed: {type(exc).__name__}", file=sys.stderr)
+                return None
+            time.sleep(5 * (attempt + 1))
+    return None
+
+
+def measure(codes: list[str]) -> None:
+    header = f"{'Country':10} {'baseline(P17)':>14} {'expanded':>10} {'lift':>8}"
+    print(header)
+    print("-" * len(header))
+    for code in codes:
+        code = code.upper()
+        qid = COUNTRY_QIDS.get(code)
+        if not qid:
+            print(f"{code:10} {'unknown country code':>33}")
+            continue
+        base = _run_count(_baseline_where(qid))
+        time.sleep(2)
+        exp = _run_count(_expanded_where(qid))
+        time.sleep(2)
+        if base is None or exp is None:
+            print(f"{code:10} {str(base):>14} {str(exp):>10} {'ERR':>8}")
+            continue
+        lift = f"+{round((exp - base) / base * 100)}%" if base else "n/a"
+        print(f"{code:10} {base:>14} {exp:>10} {lift:>8}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("countries", nargs="*", help="ISO alpha-2 codes")
+    parser.add_argument("--all", action="store_true", help="measure all 54 countries")
+    args = parser.parse_args()
+
+    if args.all:
+        codes = sorted(COUNTRY_QIDS.keys())
+    elif args.countries:
+        codes = args.countries
+    else:
+        codes = DEFAULT_COUNTRIES
+    measure(codes)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -105,6 +105,140 @@ def test_wikidata_scraper_query_build():
     assert "positionLabel" in query
 
 
+def test_wikidata_jurisdiction_query_uses_p1001():
+    from africapep.scraper.spiders.wikidata_scraper import _build_jurisdiction_query
+
+    query = _build_jurisdiction_query("Q1007")  # Guinea-Bissau
+    assert "wdt:P1001 wd:Q1007" in query
+    assert "personLabel" in query
+
+
+def test_wikidata_citizenship_query_uses_p27_and_returns_position():
+    from africapep.scraper.spiders.wikidata_scraper import _build_citizenship_query
+
+    query = _build_citizenship_query("Q986")  # Eritrea
+    assert "wdt:P27 wd:Q986" in query
+    # The position QID must be selectable so it can be office-class filtered
+    assert "?position " in query
+
+
+def test_wikidata_office_class_filter():
+    from africapep.scraper.spiders.wikidata_scraper import (
+        _build_office_class_filter,
+        PUBLIC_OFFICE_QID,
+    )
+
+    query = _build_office_class_filter(["Q30461", "Q83307"])
+    assert "VALUES ?position" in query
+    assert "wd:Q30461" in query and "wd:Q83307" in query
+    assert f"wdt:P279* wd:{PUBLIC_OFFICE_QID}" in query
+
+
+def test_wikidata_queries_are_multilingual():
+    from africapep.scraper.spiders.wikidata_scraper import (
+        _build_query,
+        _build_jurisdiction_query,
+        _build_citizenship_query,
+        LABEL_LANGS,
+    )
+
+    # English must remain first so Latin/searchable names win
+    assert LABEL_LANGS.startswith("en")
+    for q in (_build_query("Q1"), _build_jurisdiction_query("Q1"),
+              _build_citizenship_query("Q1")):
+        assert f'wikibase:language "{LABEL_LANGS}"' in q
+
+
+def _sparql_response(bindings):
+    """Build a mock requests.Response carrying SPARQL JSON bindings."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"results": {"bindings": bindings}}
+    return resp
+
+
+def test_wikidata_multi_branch_merges_and_office_filters():
+    """All three branches merge; citizenship branch keeps only public offices."""
+    import urllib.parse
+    from africapep.scraper.spiders.wikidata_scraper import WikidataScraper
+
+    ent = "http://www.wikidata.org/entity/"
+    branch_a = [{
+        "person": {"value": ent + "Q1"},
+        "personLabel": {"value": "Alpha ViaP17"},
+        "positionLabel": {"value": "President"},
+    }]
+    branch_b = [{
+        "person": {"value": ent + "Q2"},
+        "personLabel": {"value": "Beta ViaP1001"},
+        "positionLabel": {"value": "Minister of Finance"},
+    }]
+    citizen_candidates = [
+        {  # holds a public office -> should be kept
+            "person": {"value": ent + "Q3"},
+            "position": {"value": ent + "Q100"},
+            "personLabel": {"value": "Gamma Citizen"},
+            "positionLabel": {"value": "Senator"},
+        },
+        {  # holds a non-office position -> should be dropped
+            "person": {"value": ent + "Q4"},
+            "position": {"value": ent + "Q200"},
+            "personLabel": {"value": "Delta Athlete"},
+            "positionLabel": {"value": "Footballer"},
+        },
+    ]
+    office_class = [{"position": {"value": ent + "Q100"}}]  # only Q100 is a public office
+
+    def dispatch(url, timeout=None):
+        q = urllib.parse.unquote(url)
+        if "P279" in q:
+            return _sparql_response(office_class)
+        if "P1001" in q:
+            return _sparql_response(branch_b)
+        if "wdt:P27" in q:
+            return _sparql_response(citizen_candidates)
+        return _sparql_response(branch_a)  # P17 baseline
+
+    with patch("africapep.scraper.base_scraper.time.sleep"), \
+         patch("africapep.scraper.spiders.wikidata_scraper.time.sleep"):
+        scraper = WikidataScraper(country_code="GW")
+        scraper.session.get = MagicMock(side_effect=dispatch)
+        records = scraper.scrape()
+
+    names = sorted(r.full_name for r in records)
+    assert names == ["Alpha ViaP17", "Beta ViaP1001", "Gamma Citizen"]
+    # The footballer (non-public-office citizen) must be excluded
+    assert "Delta Athlete" not in names
+
+
+def test_wikidata_branch_failure_does_not_regress_baseline():
+    """If a broad branch fails, the P17 baseline branch still returns results."""
+    import urllib.parse
+    from africapep.scraper.spiders.wikidata_scraper import WikidataScraper
+
+    ent = "http://www.wikidata.org/entity/"
+    branch_a = [{
+        "person": {"value": ent + "Q1"},
+        "personLabel": {"value": "Alpha ViaP17"},
+        "positionLabel": {"value": "President"},
+    }]
+
+    def dispatch(url, timeout=None):
+        q = urllib.parse.unquote(url)
+        if "wdt:P17" in q and "P1001" not in q and "wdt:P27" not in q:
+            return _sparql_response(branch_a)
+        raise Exception("branch unavailable")  # B and C blow up
+
+    with patch("africapep.scraper.base_scraper.time.sleep"), \
+         patch("africapep.scraper.spiders.wikidata_scraper.time.sleep"):
+        scraper = WikidataScraper(country_code="GW")
+        scraper.session.get = MagicMock(side_effect=dispatch)
+        records = scraper.scrape()
+
+    # Baseline coverage preserved despite the other branches failing
+    assert [r.full_name for r in records] == ["Alpha ViaP17"]
+
+
 def test_wikidata_scraper_parse_date():
     from africapep.scraper.spiders.wikidata_scraper import _parse_date
 
@@ -141,7 +275,8 @@ def test_wikidata_scraper_scrape_with_mock():
         }
     }
 
-    with patch("africapep.scraper.spiders.wikidata_scraper.time.sleep"):
+    with patch("africapep.scraper.spiders.wikidata_scraper.time.sleep"), \
+         patch("africapep.scraper.base_scraper.time.sleep"):
         scraper = WikidataScraper(country_code="NG")
         scraper.session.get = MagicMock(return_value=mock_response)
         records = scraper.scrape()
@@ -184,7 +319,8 @@ def test_wikidata_scraper_deduplicates():
         }
     }
 
-    with patch("africapep.scraper.spiders.wikidata_scraper.time.sleep"):
+    with patch("africapep.scraper.spiders.wikidata_scraper.time.sleep"), \
+         patch("africapep.scraper.base_scraper.time.sleep"):
         scraper = WikidataScraper(country_code="GH")
         scraper.session.get = MagicMock(return_value=mock_response)
         records = scraper.scrape()
@@ -196,7 +332,8 @@ def test_wikidata_scraper_deduplicates():
 def test_wikidata_scraper_handles_api_error():
     from africapep.scraper.spiders.wikidata_scraper import WikidataScraper
 
-    with patch("africapep.scraper.spiders.wikidata_scraper.time.sleep"):
+    with patch("africapep.scraper.spiders.wikidata_scraper.time.sleep"), \
+         patch("africapep.scraper.base_scraper.time.sleep"):
         scraper = WikidataScraper(country_code="GH")
         scraper.session.get = MagicMock(side_effect=Exception("API timeout"))
         # run() catches exceptions and returns []
@@ -212,7 +349,8 @@ def test_wikidata_scraper_run_returns_list():
     mock_response.status_code = 200
     mock_response.json.return_value = {"results": {"bindings": []}}
 
-    with patch("africapep.scraper.spiders.wikidata_scraper.time.sleep"):
+    with patch("africapep.scraper.spiders.wikidata_scraper.time.sleep"), \
+         patch("africapep.scraper.base_scraper.time.sleep"):
         scraper = WikidataScraper(country_code="GH")
         scraper.session.get = MagicMock(return_value=mock_response)
         records = scraper.run()


### PR DESCRIPTION
## Problem

The bottom six countries by PEP coverage (Guinea-Bissau, São Tomé, Djibouti, Lesotho, Seychelles, Eritrea) were under-served because the scraper matched a person only when **the position itself carried `country (P17)`**:

```sparql
?person wdt:P39 ?position .
?position wdt:P17 wd:{country} .   # ← the bottleneck
```

Many political positions — especially in small / non-anglophone countries — are tied to their country via **`applies to jurisdiction (P1001)`** instead, or the office-holder is only reachable via **citizenship (P27)**. Labels were also English-only, silently dropping Portuguese/French/Arabic/Tigrinya officials with no English label.

## Change

A three-branch catchment, merged and deduplicated by `(name, position)`:

| Branch | Match | Notes |
|--------|-------|-------|
| **A** | position `P17` = country | Original query, kept **standalone** so coverage never regresses if a broader branch times out |
| **B** | position `P1001` = country | The main structural gap |
| **C** | citizen `P27` + position is a `P279*` subclass of **public office (Q294414)** | Two-step (candidates → office-class filter over a bounded `VALUES` set) to stay under the SPARQL timeout; office-class guard preserves the existing seniority definition |

Plus: labels now use a **Latin-first multilingual chain** `en,pt,fr,es,sw,ar,ti`.

Constraints honoured: **same source** (Wikidata), **same seniority definition** (classifier unchanged; office-class guard on Branch C), **verifiable-only** (every record QID-backed). Each branch degrades independently — no regression below today's baseline.

## Measured lift (distinct principals, live Wikidata)

| Country | Baseline (P17) | Expanded | Lift |
|---|---|---|---|
| Guinea-Bissau | 149 | 353 | **+137%** |
| Lesotho | 129 | 286 | **+122%** |
| Djibouti | 119 | 199 | **+67%** |
| São Tomé | 111 | 133 | +20% |
| Seychelles | 94 | 105 | +12% |
| Eritrea | 77 | 88 | +14% |

São Tomé / Seychelles / Eritrea are near Wikidata's ceiling — the data for more senior principals does not exist in the source; raising those further requires new data sources (out of scope here).

## Verification

- `scripts/measure_coverage.py` reports per-country lift against live Wikidata (`python -m scripts.measure_coverage`).
- New unit tests: each branch builder, the office-class filter, multi-branch merge + office filtering, and **no-regression** when broad branches fail.
- Full unit suite: **102 passed**.

## Not included / next step

This changes *extraction* only. To realise the lift in the live DB, the weekly scrape → resolve → Neo4j → PostgreSQL sync must run against the production databases (requires the DB environment).