### PR TITLE
fix: stop cross-run Person node duplication (stable QID-based id)

### DIFF
--- a/africapep/pipeline/resolver.py
+++ b/africapep/pipeline/resolver.py
@@ -158,8 +158,14 @@ class EntityResolver:
                      existing=self.entities[best_match_id].full_name,
                      score=round(best_score, 3))
 
-        # Create new entity
-        entity_id = str(uuid.uuid4())
+        # Create new entity.
+        # The id is the Neo4j MERGE key, so it MUST be stable across scrape
+        # runs -- otherwise each run mints a fresh uuid and MERGE creates a
+        # duplicate Person node every time (the cause of ~4-7x count
+        # inflation). Derive it from the Wikidata QID when available; fall
+        # back to a uuid only for records with no QID (e.g. non-Wikidata
+        # sources), which cannot be cross-run deduplicated anyway.
+        entity_id = f"wd:{wikidata_qid}" if wikidata_qid else str(uuid.uuid4())
         entity = ResolvedEntity(
             id=entity_id,
             full_name=record.full_name,

--- a/tests/test_entity_resolution.py
+++ b/tests/test_entity_resolution.py
@@ -35,6 +35,36 @@ class TestEntityResolver:
         assert len(resolver.entities) == 1
         assert resolver.entities[entity_id].full_name == "Kwame Mensah"
 
+    def test_person_id_stable_across_runs_via_qid(self):
+        """Same Wikidata QID must map to the same Person id across separate runs.
+
+        Each scrape run builds a fresh EntityResolver, so the in-memory QID
+        cache cannot deduplicate against prior runs. The Person id must
+        therefore be derived from the stable Wikidata QID, so the Neo4j
+        ``MERGE (p:Person {id})`` updates the existing node instead of
+        creating a duplicate every run (the cause of ~4-7x count inflation).
+        """
+        from africapep.pipeline.resolver import EntityResolver
+
+        rec = _make_record("Dionisio Cabi", country="GW")
+        rec.extra_fields = {"wikidata_qid": "Q123"}
+
+        # Two independent resolvers simulate two separate scrape runs.
+        id_run1 = EntityResolver().add(rec, 1)
+        id_run2 = EntityResolver().add(rec, 1)
+
+        assert id_run1 == id_run2, "Person id must be stable across runs for a QID"
+        assert id_run1 == "wd:Q123"
+
+    def test_person_id_falls_back_to_uuid_without_qid(self):
+        """Records with no QID still get a (unique) id and don't crash."""
+        from africapep.pipeline.resolver import EntityResolver
+
+        rec = _make_record("Anonymous Associate", country="GW")  # no extra_fields qid
+        entity_id = EntityResolver().add(rec, 2)
+
+        assert entity_id and not entity_id.startswith("wd:")
+
     def test_exact_name_merge(self):
         from africapep.pipeline.resolver import EntityResolver
 


### PR DESCRIPTION
## Root cause

`EntityResolver` minted a random `uuid4` as each new entity's id (`resolver.py:162`), and that id is the Neo4j MERGE key (`MERGE (p:Person {id})`). A fresh resolver is built every scrape run, and the QID dedup cache (`_qid_to_entity`) is **in-memory per run** — so it deduplicated *within* a run but never *across* runs. Each weekly run therefore minted new uuids and MERGE created a **duplicate Person node every time**.

**Impact:** ~4–7× duplicate Person nodes accumulated (one set per run since launch), inflating per-country PEP counts. Guinea-Bissau showed **672 rows for ~150 distinct people** (672 rows = 672 distinct `neo4j_id`, confirming graph-level duplication).

## Fix

Derive the entity id from the stable **Wikidata QID** (`wd:<QID>`) when available; fall back to `uuid4` only for records with no QID. MERGE now matches the same node across runs and updates it instead of duplicating.

This propagates correctly to PostgreSQL: `pep_profiles` dedupes via `ON CONFLICT (neo4j_id)`, and `sync.py` derives its PK from `uuid5(namespace, neo4j_id)` — both accept the `wd:Q123` string, yielding **one row per person**.

## Tests

- `test_person_id_stable_across_runs_via_qid` — two independent resolvers (= two runs) produce the **same** id for the same QID (was: two different uuids).
- `test_person_id_falls_back_to_uuid_without_qid` — QID-less records still get a unique id.
- Full suite: **116 passed**.

## Scope / next step

This **stops future duplication**. It does **not** retroactively collapse the existing historical duplicates — that's a separate data migration (`scripts/dedup_neo4j.py` or a clean rebuild), to be sequenced during deploy. Until then, deploying this fix is safe and strictly prevents the problem getting worse.