### PR TITLE
fix: raise scraper SPARQL timeout so Branch C (citizenship) lands

### DIFF
--- a/africapep/config.py
+++ b/africapep/config.py
@@ -10,6 +10,11 @@ class Settings(BaseSettings):
     postgres_url: str = ""
     log_level: str = "INFO"
     scraper_delay_seconds: float = 2.0
+    # Default HTTP read timeout for scraper requests (seconds).
+    scraper_timeout_seconds: int = 30
+    # Longer timeout for heavy SPARQL queries (e.g. the P279* office-class
+    # subclass walk in the citizenship branch), which exceed the default.
+    scraper_sparql_timeout_seconds: int = 90
     environment: str = "development"
 
     # API authentication

--- a/africapep/scraper/base_scraper.py
+++ b/africapep/scraper/base_scraper.py
@@ -40,6 +40,8 @@ class BaseScraper(ABC):
     country_code: str = ""
     source_type: str = ""
     delay_seconds: float = settings.scraper_delay_seconds
+    # HTTP read timeout (seconds). Subclasses with heavier queries override this.
+    request_timeout: int = settings.scraper_timeout_seconds
 
     def __init__(self):
         self.session = requests.Session()
@@ -66,7 +68,7 @@ class BaseScraper(ABC):
         delay = self.delay_seconds + random.uniform(0, 1)
         time.sleep(delay)
         log.info("scraper_request", url=url, delay=round(delay, 1))
-        resp = self.session.get(url, timeout=30)
+        resp = self.session.get(url, timeout=self.request_timeout)
         log.info("scraper_response", url=url, status=resp.status_code)
         resp.raise_for_status()
         return resp

--- a/africapep/scraper/spiders/wikidata_scraper.py
+++ b/africapep/scraper/spiders/wikidata_scraper.py
@@ -18,6 +18,7 @@ from typing import Dict, List, Optional
 import requests
 import structlog
 
+from africapep.config import settings
 from africapep.scraper.base_scraper import BaseScraper, RawPersonRecord
 
 log = structlog.get_logger(__name__)
@@ -234,6 +235,10 @@ class WikidataScraper(BaseScraper):
     """Scraper that pulls PEP data from Wikidata's SPARQL endpoint."""
 
     source_type = "WIKIDATA"
+    # SPARQL queries (esp. the citizenship branch's P279* office-class walk)
+    # routinely exceed the base 30s timeout; use the longer SPARQL timeout so
+    # Branch C lands instead of timing out.
+    request_timeout = settings.scraper_sparql_timeout_seconds
 
     def __init__(self, country_code: str, since: Optional[str] = None):
         """
@@ -482,6 +487,7 @@ def _determine_is_current(
 class _RegionalHelper(BaseScraper):
     """Minimal BaseScraper subclass used only to access _get() with retry."""
     source_type = "WIKIDATA"
+    request_timeout = settings.scraper_sparql_timeout_seconds
 
     def scrape(self) -> List[RawPersonRecord]:
         return []  # pragma: no cover

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -105,6 +105,40 @@ def test_wikidata_scraper_query_build():
     assert "positionLabel" in query
 
 
+def test_get_uses_configurable_request_timeout():
+    """_get passes the instance request_timeout to session.get, not a hardcoded value."""
+    from africapep.scraper.spiders.wikidata_scraper import WikidataScraper
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"results": {"bindings": []}}
+
+    with patch("africapep.scraper.spiders.wikidata_scraper.time.sleep"), \
+         patch("africapep.scraper.base_scraper.time.sleep"):
+        scraper = WikidataScraper(country_code="GH")
+        scraper.request_timeout = 90
+        scraper.session.get = MagicMock(return_value=mock_response)
+        scraper._get("https://example.com/sparql")
+
+    _, kwargs = scraper.session.get.call_args
+    assert kwargs.get("timeout") == 90, "should pass the instance request_timeout through"
+
+
+def test_wikidata_scraper_uses_longer_sparql_timeout():
+    """The Wikidata scraper needs a longer timeout than the base default.
+
+    The citizenship/office-class branch runs a P279* subclass walk that takes
+    far longer than the 30s base timeout, so it must use the dedicated longer
+    SPARQL timeout or it always times out (Branch C dropped in production).
+    """
+    from africapep.scraper.base_scraper import BaseScraper
+    from africapep.scraper.spiders.wikidata_scraper import WikidataScraper
+
+    scraper = WikidataScraper(country_code="GH")
+    assert scraper.request_timeout > BaseScraper.request_timeout
+    assert scraper.request_timeout >= 90
+
+
 def test_wikidata_jurisdiction_query_uses_p1001():
     from africapep.scraper.spiders.wikidata_scraper import _build_jurisdiction_query
 


### PR DESCRIPTION
## Problem

The expanded catchment's **Branch C** (citizens holding a public office) runs a `P279*` office-class subclass walk that takes **40–100s** against live Wikidata. But `BaseScraper._get` hardcoded a **30s** HTTP read timeout, so every office-class query raised `ReadTimeout` in production — **44 failures** in a full 54-country run. Branch C was silently dropped; only P17 + P1001 landed, suppressing the very coverage the expansion was meant to add (largest headroom: Guinea-Bissau, Lesotho, Djibouti).

## Fix

Make the HTTP timeout configurable instead of a magic `30`:
- `settings.scraper_timeout_seconds` (default **30**) → `BaseScraper.request_timeout`
- `settings.scraper_sparql_timeout_seconds` (default **90**) → overridden on `WikidataScraper` and `_RegionalHelper`
- `_get` now passes `self.request_timeout`

## Verified against live Wikidata

The Guinea-Bissau office-class filter (the exact query that was failing) now completes in **48s**, keeping **36 public offices** from 45 candidate positions — data that was previously dropped. (Citizenship candidate query also took 34s, i.e. also previously at risk.)

## Tests

- `test_get_uses_configurable_request_timeout` — `_get` passes the instance timeout to `session.get`.
- `test_wikidata_scraper_uses_longer_sparql_timeout` — Wikidata timeout exceeds the base default.
- Full suite: **118 passed**.

## Note

Graceful per-branch degradation is retained: if an office-class query still times out (WDQS can be slow under load), A+B coverage is unaffected — strictly no regression.