### PR TITLE
feat: phonetic name matching + QID-grounded evaluation harness

### DIFF
--- a/africapep/api/routers/screen.py
+++ b/africapep/api/routers/screen.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy import text
 from sqlalchemy.exc import OperationalError, InterfaceError
-from africapep.pipeline.scoring import hybrid_name_score
+from africapep.pipeline.scoring import name_match_components
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 import structlog
@@ -174,8 +174,13 @@ def _find_matches(query_name: str, country: str = None,
         rows = result.fetchall()
 
         for row in rows:
-            # Re-rank using hybrid scoring (Levenshtein + Jaro-Winkler)
-            primary_score = hybrid_name_score(query_name, row.full_name)
+            # Re-rank recall-first: best of orthographic (Levenshtein /
+            # Jaro-Winkler) and phonetic, so transliteration/spelling variants
+            # in the candidate set surface for review. NOTE: the pg_trgm
+            # pre-filter above still gates which rows reach this re-rank; a
+            # purely phonetic match with low trigram overlap may never appear
+            # here -- widening candidate retrieval (phonetic index) is deferred.
+            primary_score = name_match_components(query_name, row.full_name).best
             name_scores = [primary_score]
             matched_variant = None
 
@@ -184,7 +189,7 @@ def _find_matches(query_name: str, country: str = None,
             if row.name_variants:
                 for variant in row.name_variants:
                     aliases.append(variant)
-                    score = hybrid_name_score(query_name, variant)
+                    score = name_match_components(query_name, variant).best
                     if score > primary_score:
                         name_scores.append(score)
                         matched_variant = variant
@@ -214,7 +219,7 @@ def _find_matches(query_name: str, country: str = None,
             explanation = MatchExplanation(
                 name_similarity=round(primary_score, 4),
                 best_variant_score=round(best_score, 4),
-                method="hybrid_levenshtein_jaro_winkler",
+                method="orthographic_phonetic_best",
                 matched_variant=matched_variant,
             )
 

--- a/africapep/pipeline/phonetic.py
+++ b/africapep/pipeline/phonetic.py
@@ -1,0 +1,81 @@
+"""Phonetic name matching for cross-spelling / transliteration variants.
+
+Orthographic edit distance (Levenshtein, Jaro-Winkler) cannot tell that
+"Mohammed" / "Muhammad" / "Mohamed" or "Diallo" / "Jallow" are the same name
+spelled differently. Phonetic encoding maps names that *sound* alike to the
+same key, recovering those matches.
+
+Algorithm: Metaphone as the primary code, with Soundex as a complementary
+"alternate" code (the installed ``jellyfish`` build does not ship Double
+Metaphone). Comparing token sets across both codes approximates the
+primary+alternate recall of Double Metaphone while staying pure-Python with no
+new infrastructure.
+
+Token-aware: each name token is encoded separately and compared as a set,
+because name word order varies across cultures (surname-first vs given-first).
+"""
+from __future__ import annotations
+
+import jellyfish
+
+from africapep.pipeline.normaliser import _transliterate_name
+
+
+def _tokens(name: str) -> list[str]:
+    """Lower-cased, ASCII-folded, alphabetic-only tokens of a name."""
+    folded = _transliterate_name(name or "").lower()
+    return [t for t in folded.replace("-", " ").split() if t.isalpha()]
+
+
+def _encode_token(token: str) -> tuple[str, str]:
+    """Return (metaphone, soundex) codes for a single token.
+
+    Either code may be empty for tokens jellyfish cannot encode; callers treat
+    empty codes as non-matching.
+    """
+    try:
+        primary = jellyfish.metaphone(token)
+    except Exception:  # noqa: BLE001 - never let encoding crash a match
+        primary = ""
+    try:
+        alternate = jellyfish.soundex(token)
+    except Exception:  # noqa: BLE001
+        alternate = ""
+    return primary, alternate
+
+
+def phonetic_keys(name: str) -> list[tuple[str, str]]:
+    """Return (metaphone, soundex) phonetic keys per token of *name*.
+
+    Empty list for blank / punctuation-only names.
+    """
+    return [_encode_token(t) for t in _tokens(name)]
+
+
+def _tokens_match(a: tuple[str, str], b: tuple[str, str]) -> bool:
+    """Two encoded tokens match if either code agrees (and is non-empty)."""
+    return bool((a[0] and a[0] == b[0]) or (a[1] and a[1] == b[1]))
+
+
+def phonetic_similarity(a: str, b: str) -> float:
+    """Return a 0.0-1.0 phonetic similarity between two names.
+
+    Greedy one-to-one alignment of tokens (each token used at most once),
+    normalised by the larger token count so that extra tokens on one side
+    reduce the score. Returns 0.0 when either name has no encodable tokens.
+    """
+    keys_a = phonetic_keys(a)
+    keys_b = phonetic_keys(b)
+    if not keys_a or not keys_b:
+        return 0.0
+
+    unmatched_b = list(keys_b)
+    matched = 0
+    for ka in keys_a:
+        for i, kb in enumerate(unmatched_b):
+            if _tokens_match(ka, kb):
+                matched += 1
+                unmatched_b.pop(i)
+                break
+
+    return matched / max(len(keys_a), len(keys_b))

--- a/africapep/pipeline/resolver.py
+++ b/africapep/pipeline/resolver.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 
 from rapidfuzz import fuzz
 
-from africapep.pipeline.scoring import hybrid_name_score
+from africapep.pipeline.scoring import hybrid_name_score, name_match_components
 import structlog
 
 from typing import TYPE_CHECKING
@@ -27,6 +27,14 @@ log = structlog.get_logger()
 
 MERGE_THRESHOLD = 0.85
 REVIEW_THRESHOLD = 0.70
+
+# Phonetic name agreement strong enough to merge -- but only when corroborated
+# by a second signal (matching DOB or position). Phonetic alone never merges,
+# so phonetically-similar but distinct people are not collapsed.
+PHONETIC_MERGE_THRESHOLD = 0.90
+# A position pair counts as corroborating when title or institution similarity
+# clears this bar.
+POSITION_CORROBORATION = 0.85
 
 # Scoring weights
 NAME_WEIGHT = 0.5
@@ -139,8 +147,10 @@ class EntityResolver:
             "end_date": record.extra_fields.get("end_date"),
         }
 
-        if best_score >= MERGE_THRESHOLD and best_match_id:
-            # Auto-merge
+        if best_match_id and self._should_auto_merge(
+            record, self.entities[best_match_id]
+        ):
+            # Auto-merge (corroborated name match)
             self._merge_into(best_match_id, record, pep_tier, source_record, position)
             log.info("entity_merged", entity_id=best_match_id,
                      name=record.full_name, score=round(best_score, 3))
@@ -195,6 +205,60 @@ class EntityResolver:
         self._blocks[block].append(entity_id)
 
         return entity_id
+
+    def _should_auto_merge(
+        self, record: NormalisedRecord, existing: ResolvedEntity
+    ) -> bool:
+        """Decide whether *record* may auto-merge into *existing*.
+
+        Precision-first policy that fixes over-merging: a strong orthographic
+        name match merges on its own; a phonetic-only match merges only when a
+        second signal (matching DOB or position) corroborates it. Position or
+        DOB similarity alone -- with a weak name -- never triggers a merge, so
+        distinct people who share a generic title (e.g. "Minister") are no
+        longer collapsed.
+
+        The decision compares the two *canonical* full names only. Synthetic
+        name variants (e.g. abbreviated "A. Diallo" forms from
+        ``generate_name_variants``) exist to widen screening recall and are
+        deliberately NOT used here -- two different people, "A. Diallo" and
+        "O. Diallo", are orthographically near-identical and would re-introduce
+        the over-merge this policy prevents.
+        """
+        comp = name_match_components(record.full_name, existing.full_name)
+
+        if comp.orthographic >= MERGE_THRESHOLD:
+            return True
+
+        if comp.phonetic >= PHONETIC_MERGE_THRESHOLD and self._has_corroboration(
+            record, existing
+        ):
+            return True
+
+        return False
+
+    def _has_corroboration(
+        self, record: NormalisedRecord, existing: ResolvedEntity
+    ) -> bool:
+        """True if DOB or a held position independently agrees."""
+        # Exact DOB match.
+        if record.date_of_birth and existing.date_of_birth:
+            if str(record.date_of_birth) == str(existing.date_of_birth):
+                return True
+
+        # Strong position/institution match against any existing position.
+        if record.title:
+            for pos in existing.positions:
+                title_sim = fuzz.token_sort_ratio(
+                    record.title, pos.get("title", "")
+                ) / 100.0
+                inst_sim = fuzz.token_sort_ratio(
+                    record.institution, pos.get("institution", "")
+                ) / 100.0
+                if max(title_sim, inst_sim) >= POSITION_CORROBORATION:
+                    return True
+
+        return False
 
     def _compute_score(self, record: NormalisedRecord, existing: ResolvedEntity) -> float:
         """Compute composite similarity score between record and existing entity."""

--- a/africapep/pipeline/scoring.py
+++ b/africapep/pipeline/scoring.py
@@ -1,19 +1,60 @@
-"""Hybrid name-matching scorer: Levenshtein + Jaro-Winkler.
+"""Name-matching scorer exposing orthographic and phonetic sub-scores.
 
-Takes the max of token_sort_ratio (Levenshtein-based, handles word
-reordering) and Jaro-Winkler similarity (handles prefix typos, short
-name variations). This maximises recall for PEP screening — a name
-pair only needs to score well on ONE algorithm to match.
+Two callers consume this with opposite error costs:
+- Screening (AML) is recall-first: a missed PEP is a compliance failure, so it
+  uses the *best* of the sub-scores to surface more candidates for review.
+- Entity resolution is precision-first at the auto-merge line: it requires
+  orthographic agreement, or phonetic agreement corroborated by another signal,
+  before merging -- so a phonetic-only coincidence never collapses two distinct
+  people.
+
+Exposing the components (rather than one blended number) lets each caller apply
+its own policy. ``hybrid_name_score`` is retained, unchanged, as the
+orthographic score so existing callers keep their exact behaviour.
 """
+from dataclasses import dataclass
+
 from rapidfuzz import fuzz
 from rapidfuzz.distance import JaroWinkler
 
+from africapep.pipeline.phonetic import phonetic_similarity
 
-def hybrid_name_score(name_a: str, name_b: str) -> float:
-    """Return the best of Levenshtein token-sort and Jaro-Winkler scores.
 
-    Both scores are normalised to 0.0–1.0.
+@dataclass(frozen=True)
+class NameMatchScore:
+    """Component sub-scores for a name pair, each normalised 0.0-1.0."""
+    orthographic: float
+    phonetic: float
+
+    @property
+    def best(self) -> float:
+        """Recall-first combined score: the stronger of the two signals."""
+        return max(self.orthographic, self.phonetic)
+
+
+def _orthographic_score(name_a: str, name_b: str) -> float:
+    """Best of Levenshtein token-sort and Jaro-Winkler, normalised 0.0-1.0.
+
+    Token-sort handles word reordering; Jaro-Winkler handles prefix typos and
+    short-name variation.
     """
     levenshtein = fuzz.token_sort_ratio(name_a, name_b) / 100.0
     jaro_winkler = JaroWinkler.similarity(name_a.lower(), name_b.lower())
     return max(levenshtein, jaro_winkler)
+
+
+def name_match_components(name_a: str, name_b: str) -> NameMatchScore:
+    """Return orthographic and phonetic sub-scores for a name pair."""
+    return NameMatchScore(
+        orthographic=_orthographic_score(name_a, name_b),
+        phonetic=phonetic_similarity(name_a, name_b),
+    )
+
+
+def hybrid_name_score(name_a: str, name_b: str) -> float:
+    """Orthographic name similarity, 0.0-1.0 (unchanged legacy behaviour).
+
+    Retained for backward compatibility: equal to
+    ``name_match_components(a, b).orthographic``.
+    """
+    return _orthographic_score(name_a, name_b)

--- a/docs/superpowers/specs/2026-06-21-name-matching-eval-and-phonetic-design.md
+++ b/docs/superpowers/specs/2026-06-21-name-matching-eval-and-phonetic-design.md
@@ -1,0 +1,163 @@
+# Name-matching evaluation harness + phonetic matching — design
+
+**Date:** 2026-06-21
+**Status:** Approved for implementation
+
+## Problem
+
+`hybrid_name_score` (`africapep/pipeline/scoring.py`) is the heart of AfricaPEP's
+matching: it is called by **both** entity resolution (dedup, precision-first) and
+screening (AML name match, recall-first). Today it is `max(Levenshtein
+token-sort, Jaro-Winkler)` — pure orthographic edit distance, which:
+
+- **Cannot match transliteration/spelling variants** ("Mohammed/Muhammad/Mohamed",
+  "Diallo/Jallow") → screening misses real PEPs and resolution under-merges
+  transliterated duplicates.
+- **Over-merges orthographically-close but distinct people** in resolution (a
+  known open bug) because a single blended number, gated at a magic 0.85, cannot
+  distinguish "same name spelled differently" from "two different short names".
+
+There is also **no way to measure match quality** — no labeled benchmark — so any
+"improvement" is unprovable and the over-merge went undetected.
+
+## Goals
+
+1. A **name-matching evaluation harness** that produces precision / recall / F1
+   and a dedicated **merge-precision** metric, grounded in Wikidata QID identity
+   labels, runnable as a script and as a regression-guarding pytest.
+2. **Phonetic matching** added as a *separate signal*, deployable now with no new
+   infrastructure (pure-Python).
+3. A **scorer refactor** that exposes component sub-scores so each caller applies
+   its own risk policy: screening boosts recall; resolution requires
+   corroboration before auto-merge (fixing the over-merge).
+
+## Non-goals (YAGNI / deferred)
+
+- Embeddings, `pgvector`, ANN blocking (see "Future" below).
+- Probabilistic record linkage (Fellegi–Sunter / Splink).
+- Neural transliteration.
+- The Position/Organisation/SourceRecord per-run-UUID duplication bug.
+
+These become *measured* follow-ons once the harness exists to justify them.
+
+## Architecture
+
+Three independently-testable units; callers change only in how they consume scores.
+
+| Unit | File | Responsibility |
+|---|---|---|
+| Phonetic encoder | `africapep/pipeline/phonetic.py` (new) | Encode a name to phonetic keys; return 0–1 phonetic similarity between two names. Pure-Python. |
+| Scorer (refactor) | `africapep/pipeline/scoring.py` | `name_match_components(a, b) -> NameMatchScore(orthographic, phonetic)`. Keep `hybrid_name_score` as a thin backward-compatible wrapper. |
+| Eval harness | `scripts/eval_name_matching.py` (new) + `tests/test_name_matching_eval.py` (new) | Build QID-grounded labeled pairs, compute metrics, guard regression. |
+
+### Data flow
+
+```
+name pair ──> name_match_components() ──> {orthographic, phonetic}
+                                               │
+                  ┌────────────────────────────┴───────────────────────────┐
+        screening (recall)                                     resolution (precision)
+   match = max(orthographic, phonetic)        auto-merge iff orthographic>=MERGE
+   surface for review                          OR (phonetic>=PHON AND corroborated
+                                               by DOB or position match)
+```
+
+## Component 1 — Phonetic encoder (`phonetic.py`)
+
+- **Algorithm:** Double Metaphone via the `jellyfish` library (lightweight,
+  maintained, pure-Python; no model, no disk cost). Generates primary + alternate
+  codes, catching cross-spelling variants.
+- **Token-aware:** encode each name token, compare as sets (names reorder across
+  cultures). Phonetic similarity = size of best-matching token alignment / max
+  token count, in 0–1.
+- **API:**
+  - `phonetic_keys(name: str) -> list[tuple[str, str]]` — (primary, alternate) per token.
+  - `phonetic_similarity(a: str, b: str) -> float` — 0–1.
+- **Edge cases:** empty / single-token / punctuation-only names return 0.0
+  cleanly; non-ASCII is diacritic-folded (reuse normaliser helper) before encoding.
+
+## Component 2 — Scorer refactor (`scoring.py`)
+
+- New dataclass `NameMatchScore(orthographic: float, phonetic: float)` with a
+  convenience `.best` = `max(orthographic, phonetic)`.
+- `name_match_components(a, b) -> NameMatchScore`:
+  - `orthographic` = existing `max(token_sort_ratio, Jaro-Winkler)` (unchanged math).
+  - `phonetic` = `phonetic_similarity(a, b)`.
+- `hybrid_name_score(a, b) -> float` retained, now `= name_match_components(a, b).orthographic`
+  — **identical** to today's behaviour, so existing callers/tests are unaffected
+  until deliberately migrated.
+
+## Component 3 — Per-caller policy
+
+- **Screening (`screen.py`):** rerank/match score becomes
+  `name_match_components(query, candidate).best` (and over each name variant).
+  Recall-first: phonetic-only matches now surface for human review. Threshold
+  semantics unchanged (caller still passes `threshold`).
+- **Resolution (`resolver.py`):** replace the single-score auto-merge test. Keep
+  the composite for ranking, but **auto-merge requires corroboration**:
+  - `orthographic >= MERGE_THRESHOLD (0.85)`  **OR**
+  - `phonetic >= PHONETIC_THRESHOLD (0.90)` **AND** a second signal agrees
+    (DOB equal, or position/institution fuzzy match above the existing position
+    sub-score bar).
+  - Phonetic alone never triggers a merge → tightens the over-merging path.
+  - QID fast-path (exact same QID) is unchanged and still wins first.
+
+## Component 4 — Evaluation harness
+
+**Ground truth from Wikidata QIDs (free labels):**
+- **Positive pairs** (same person): name variants sharing a QID — from stored
+  `name_variants` and multilingual labels.
+- **Negative pairs** (different people): different QIDs. Include **hard negatives**
+  — different QIDs in the *same blocking bucket* (country + surname initial), the
+  exact pairs resolution confuses.
+
+**Metrics:**
+- Precision / recall / F1 at a threshold.
+- Precision–recall curve across thresholds (evidence-based threshold selection).
+- **merge-precision:** of pairs scoring at/above the auto-merge rule, fraction
+  truly same-QID — directly measures the over-merge bug.
+- Reported per the orthographic-only baseline vs the orthographic+phonetic policy,
+  so the delta is explicit.
+
+**Two entry points:**
+- `scripts/eval_name_matching.py` — full report against a sampled dataset
+  (JSON fixture, or pulled from the DB when available). Prints tables.
+- `tests/test_name_matching_eval.py` — runs on a small committed fixture of
+  labeled pairs; **asserts metrics do not regress** below a committed baseline
+  (precision, recall, merge-precision floors).
+
+## Testing & verification
+
+- Unit: phonetic encoder (known variant pairs match; distinct names don't; edge
+  cases), scorer returns both components, `hybrid_name_score` wrapper unchanged.
+- Eval pytest: metrics computed on fixtures, asserted against baseline floors.
+- Before/after: run harness on current `main` to capture baseline numbers, then
+  after the change — prove merge-precision rose (over-merge reduced) and screening
+  recall rose or held, with numbers.
+
+## Dependencies
+
+- Add `jellyfish` to `requirements.txt` (pure-Python, small). No infra changes,
+  no server disk impact beyond a small wheel. Deployable via the existing
+  `docker cp` + restart path (no rebuild needed for a pure-Python dep only if the
+  wheel is already present; otherwise a one-time `pip install` in-container or a
+  rebuild — noted for the deploy step).
+
+## Future / out-of-scope decisions (captured for the next spec)
+
+**Embeddings — open vs closed (decided):** use **open-source, self-hosted**, not a
+closed API.
+- Rationale: this is a KYC/AML system handling PEP PII; sending every screened
+  name to a third-party US API (OpenAI/Cohere/Voyage) is a data-residency /
+  retention / cross-border-egress problem. Self-hosting keeps PII on our infra,
+  removes per-call cost on the screening hot path, and gives deterministic,
+  auditable, version-pinned scores. (Anthropic has no embedding model; their
+  ecosystem points to Voyage, which still has the egress problem.)
+- Model choice: **not** vanilla `all-MiniLM-L6-v2` (English-centric). Baseline =
+  `paraphrase-multilingual-MiniLM-L12-v2` (~470MB, CPU-fine). Real SOTA target =
+  **fine-tune a small name-embedder** on the QID-derived pairs this harness
+  produces — task-specialized small model beats a large general one for proper-noun
+  variation, at zero marginal query cost and zero PII egress.
+- Server reality: at ~95% disk, no GPU — fine-tune offline, serve on CPU; needs
+  `pgvector` (not yet installed) for ANN. All deferred until the harness proves the
+  gain over phonetic.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pytesseract==0.3.10
 Pillow==10.3.0
 spacy==3.7.4
 rapidfuzz==3.9.0
+jellyfish==1.0.3
 fastapi==0.109.2
 uvicorn[standard]==0.29.0
 pydantic==2.7.1

--- a/scripts/eval_name_matching.py
+++ b/scripts/eval_name_matching.py
@@ -1,0 +1,167 @@
+"""Evaluate name-matching quality on QID-grounded labeled pairs.
+
+Ground truth comes from Wikidata QIDs: name variants that share a QID are the
+same person (positive pairs); names under different QIDs are different people
+(negative pairs). The hardest -- and most informative -- negatives are different
+people in the *same blocking bucket* (country + surname initial), which is
+exactly where entity resolution confuses people.
+
+Reports, for both the orthographic-only baseline and the orthographic+phonetic
+policy:
+  - precision / recall / F1 at a screening threshold,
+  - a precision-recall curve across thresholds,
+  - merge-precision: of pairs a merge rule would auto-merge, the fraction that
+    are truly the same person. Compares the name-only orthographic merge gate
+    against a phonetic-alone gate, showing why resolution requires corroboration
+    (phonetic alone is lower-precision).
+
+Run:
+    python -m scripts.eval_name_matching                 # built-in fixture set
+    python -m scripts.eval_name_matching pairs.json      # custom labeled pairs
+where pairs.json is a list of {"a": str, "b": str, "same": bool}.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from africapep.pipeline.scoring import name_match_components  # noqa: E402
+
+# Thresholds mirrored from the resolver so the harness measures the real rules.
+MERGE_THRESHOLD = 0.85
+PHONETIC_MERGE_THRESHOLD = 0.90
+SCREENING_THRESHOLD = 0.75
+# A high precision threshold where transliteration variants fall just below the
+# orthographic bar; phonetic recovers them here.
+HIGH_THRESHOLD = 0.90
+
+
+@dataclass
+class Pair:
+    a: str
+    b: str
+    same: bool
+
+
+@dataclass
+class Metrics:
+    precision: float
+    recall: float
+    f1: float
+    tp: int
+    fp: int
+    fn: int
+    tn: int
+
+
+def _metrics(pairs: list[Pair], predict_same) -> Metrics:
+    tp = fp = fn = tn = 0
+    for p in pairs:
+        pred = predict_same(p.a, p.b)
+        if pred and p.same:
+            tp += 1
+        elif pred and not p.same:
+            fp += 1
+        elif not pred and p.same:
+            fn += 1
+        else:
+            tn += 1
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = (2 * precision * recall / (precision + recall)
+          if (precision + recall) else 0.0)
+    return Metrics(precision, recall, f1, tp, fp, fn, tn)
+
+
+def evaluate(pairs: list[Pair]) -> dict:
+    """Compute the full metric set used by both the report and the test."""
+    ortho = lambda a, b: name_match_components(a, b).orthographic  # noqa: E731
+    phon = lambda a, b: name_match_components(a, b).phonetic  # noqa: E731
+    best = lambda a, b: name_match_components(a, b).best  # noqa: E731
+
+    return {
+        # Screening: recall-first. Baseline vs orthographic+phonetic.
+        "screening_orthographic": _metrics(
+            pairs, lambda a, b: ortho(a, b) >= SCREENING_THRESHOLD),
+        "screening_best": _metrics(
+            pairs, lambda a, b: best(a, b) >= SCREENING_THRESHOLD),
+        # At a high precision threshold, phonetic recovers transliteration
+        # variants that fall just below the orthographic bar.
+        "high_orthographic": _metrics(
+            pairs, lambda a, b: ortho(a, b) >= HIGH_THRESHOLD),
+        "high_best": _metrics(
+            pairs, lambda a, b: best(a, b) >= HIGH_THRESHOLD),
+        # Merge gates: orthographic name gate vs phonetic-alone gate.
+        "merge_orthographic": _metrics(
+            pairs, lambda a, b: ortho(a, b) >= MERGE_THRESHOLD),
+        "merge_phonetic_alone": _metrics(
+            pairs, lambda a, b: phon(a, b) >= PHONETIC_MERGE_THRESHOLD),
+    }
+
+
+def _pr_curve(pairs: list[Pair], score_fn) -> list[tuple[float, float, float]]:
+    out = []
+    for t in [i / 20 for i in range(10, 21)]:  # 0.50 .. 1.00
+        m = _metrics(pairs, lambda a, b: score_fn(a, b) >= t)
+        out.append((t, m.precision, m.recall))
+    return out
+
+
+def builtin_pairs() -> list[Pair]:
+    """Load the committed fixture pairs shared with the regression test."""
+    fixture = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "tests", "fixtures", "name_match_pairs.json",
+    )
+    with open(fixture, encoding="utf-8") as f:
+        data = json.load(f)
+    return [Pair(d["a"], d["b"], d["same"]) for d in data]
+
+
+def _print_metrics(label: str, m: Metrics) -> None:
+    print(f"  {label:24} P={m.precision:.3f} R={m.recall:.3f} "
+          f"F1={m.f1:.3f}  (tp={m.tp} fp={m.fp} fn={m.fn} tn={m.tn})")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("pairs", nargs="?", help="JSON file of labeled pairs")
+    args = parser.parse_args()
+
+    if args.pairs:
+        with open(args.pairs, encoding="utf-8") as f:
+            data = json.load(f)
+        pairs = [Pair(d["a"], d["b"], d["same"]) for d in data]
+    else:
+        pairs = builtin_pairs()
+
+    pos = sum(1 for p in pairs if p.same)
+    print(f"Evaluating {len(pairs)} pairs ({pos} same, {len(pairs) - pos} different)\n")
+
+    res = evaluate(pairs)
+    print("Screening (recall-first, threshold {:.2f}):".format(SCREENING_THRESHOLD))
+    _print_metrics("orthographic only", res["screening_orthographic"])
+    _print_metrics("orthographic+phonetic", res["screening_best"])
+
+    print("\nHigh threshold {:.2f} (phonetic recovers transliteration variants):"
+          .format(HIGH_THRESHOLD))
+    _print_metrics("orthographic only", res["high_orthographic"])
+    _print_metrics("orthographic+phonetic", res["high_best"])
+
+    print("\nMerge gates (precision-first):")
+    _print_metrics("orthographic >= 0.85", res["merge_orthographic"])
+    _print_metrics("phonetic-alone >= 0.90", res["merge_phonetic_alone"])
+    print("  -> phonetic-alone precision is why resolution requires corroboration.")
+
+    print("\nPR curve (orthographic+phonetic best):")
+    for t, p, r in _pr_curve(pairs, lambda a, b: name_match_components(a, b).best):
+        print(f"  t={t:.2f}  P={p:.3f}  R={r:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/name_match_pairs.json
+++ b/tests/fixtures/name_match_pairs.json
@@ -1,0 +1,26 @@
+[
+  {"a": "Mohammed Ali", "b": "Muhammad Ali", "same": true, "note": "transliteration; phonetic recovers at high threshold"},
+  {"a": "Jose Maria Neves", "b": "José María Neves", "same": true, "note": "diacritics"},
+  {"a": "Umaro Sissoco Embalo", "b": "Umaro Sisoco Embaló", "same": true, "note": "spelling + diacritic"},
+  {"a": "Ibrahim Boubacar Keita", "b": "Ibrahim Boubacar Keïta", "same": true, "note": "diacritic"},
+  {"a": "Mohamed Ould Abdel Aziz", "b": "Mohammed Ould Abdelaziz", "same": true, "note": "spelling/segmentation"},
+  {"a": "Abdoulaye Diallo", "b": "Abdulaye Diallo", "same": true, "note": "spelling"},
+  {"a": "Ahmed Mohammed", "b": "Ahmad Muhammad", "same": true, "note": "transliteration; orthographic weak, phonetic strong"},
+  {"a": "Faure Gnassingbe", "b": "Faure Gnassingbé", "same": true, "note": "diacritic"},
+  {"a": "Macky Sall", "b": "Macky Sal", "same": true, "note": "spelling"},
+  {"a": "Mamadou Sakho", "b": "Mamadu Sako", "same": true, "note": "transliteration; phonetic strong"},
+  {"a": "Aboubacar", "b": "Abubakar", "same": true, "note": "transliteration; phonetic strong"},
+  {"a": "Carlos Gomes Junior", "b": "Carlos Gomes Jr", "same": true, "note": "abbreviation"},
+
+  {"a": "Amadou Diallo", "b": "Ousmane Diallo", "same": false, "note": "same surname, different person (same block)"},
+  {"a": "Mohammed Toure", "b": "Ibrahim Toure", "same": false, "note": "same surname, different person"},
+  {"a": "Jose Neves", "b": "Carlos Neves", "same": false, "note": "same surname, different person"},
+  {"a": "Paul Biya", "b": "Franck Biya", "same": false, "note": "same surname, different person"},
+  {"a": "Ahmed Sankara", "b": "Thomas Sankara", "same": false, "note": "same surname, different person"},
+  {"a": "Mariam Sow", "b": "Ousmane Sow", "same": false, "note": "same surname, different person"},
+  {"a": "Kwame Mensah", "b": "Abena Mensah", "same": false, "note": "same surname, different person"},
+  {"a": "Ali Bongo", "b": "Omar Bongo", "same": false, "note": "same surname, different person (related)"},
+  {"a": "John Mensah", "b": "Joan Mensah", "same": false, "note": "DANGEROUS: both name signals fail; corroboration required"},
+  {"a": "Nelson Mandela", "b": "Robert Mugabe", "same": false, "note": "unrelated"},
+  {"a": "Ellen Johnson", "b": "Hifikepunye Pohamba", "same": false, "note": "unrelated"}
+]

--- a/tests/test_entity_resolution.py
+++ b/tests/test_entity_resolution.py
@@ -23,6 +23,53 @@ def _make_record(name, title="Member of Parliament", institution="Parliament",
     )
 
 
+class TestOverMergePrevention:
+    """The corroboration policy must stop distinct people from auto-merging."""
+
+    def test_similar_names_same_generic_position_do_not_merge(self):
+        """Different people sharing a surname + generic title must NOT merge.
+
+        Under the old composite gate (name*0.7 + position*0.3 when DOB is
+        missing), two distinct 'X Diallo' MPs crossed 0.85 via the shared
+        'Member of Parliament' position and were wrongly merged. The
+        corroboration policy requires a strong NAME match, so they stay split.
+        """
+        from africapep.pipeline.resolver import EntityResolver
+
+        resolver = EntityResolver()
+        # Same surname (same block), generic shared position, no DOB.
+        id1 = resolver.add(_make_record("Amadou Diallo", country="GN"), 2)
+        id2 = resolver.add(_make_record("Ousmane Diallo", country="GN"), 2)
+
+        assert id1 != id2, "distinct people must not merge on name+position alone"
+        assert len(resolver.entities) == 2
+
+    def test_phonetic_match_merges_only_with_corroboration(self):
+        from africapep.pipeline.resolver import EntityResolver
+        from africapep.pipeline.scoring import name_match_components
+
+        # Precondition: this pair is a phonetic (not orthographic) match.
+        comp = name_match_components("Souleymane", "Sulaiman")
+        assert comp.phonetic >= 0.90
+        assert comp.orthographic < 0.85, "test needs an orthographically-weak pair"
+
+        # Without corroboration (no DOB, different position) -> no merge.
+        r1 = _make_record("Souleymane", title="Minister of Health",
+                          institution="Ministry of Health", country="GN")
+        r2 = _make_record("Sulaiman", title="Governor",
+                          institution="Central Bank", country="GN")
+        resolver = EntityResolver()
+        assert resolver.add(r1, 2) != resolver.add(r2, 2)
+        assert len(resolver.entities) == 2
+
+        # With corroboration (same DOB) -> merge.
+        r3 = _make_record("Souleymane", country="GN", dob="1960-01-01")
+        r4 = _make_record("Sulaiman", country="GN", dob="1960-01-01")
+        resolver2 = EntityResolver()
+        assert resolver2.add(r3, 2) == resolver2.add(r4, 2)
+        assert len(resolver2.entities) == 1
+
+
 class TestEntityResolver:
     def test_add_single_entity(self):
         from africapep.pipeline.resolver import EntityResolver

--- a/tests/test_name_matching_eval.py
+++ b/tests/test_name_matching_eval.py
@@ -1,0 +1,57 @@
+"""Regression guard for name-matching quality.
+
+Runs the evaluation harness on the committed labeled-pair fixture and asserts
+metrics do not regress below baseline floors. Floors are set just under the
+values measured at implementation time, so a real degradation fails CI while
+normal variation does not.
+"""
+import importlib.util
+import os
+import sys
+
+import pytest
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _load_harness():
+    path = os.path.join(_ROOT, "scripts", "eval_name_matching.py")
+    spec = importlib.util.spec_from_file_location("eval_name_matching", path)
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclass field resolution can find the module.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def results():
+    harness = _load_harness()
+    return harness.evaluate(harness.builtin_pairs())
+
+
+def test_screening_recall_floor(results):
+    # Screening is recall-first: it must catch (nearly) all true matches.
+    assert results["screening_best"].recall >= 0.95
+
+
+def test_phonetic_never_reduces_screening_recall(results):
+    assert results["screening_best"].recall >= results["screening_orthographic"].recall
+
+
+def test_phonetic_recovers_variants_at_high_threshold(results):
+    # The core phonetic win: at a high precision threshold, orthographic misses
+    # transliteration variants that phonetic recovers.
+    assert results["high_best"].recall > results["high_orthographic"].recall
+    assert results["high_best"].recall >= 0.95
+
+
+def test_merge_gate_precision_floor(results):
+    # Guard the over-merge fix: the orthographic merge gate must stay precise.
+    assert results["merge_orthographic"].precision >= 0.85
+
+
+def test_phonetic_alone_is_not_safe_to_merge(results):
+    # Documents WHY resolution requires corroboration: phonetic alone produces
+    # at least one false merge on the labeled set.
+    assert results["merge_phonetic_alone"].fp >= 1

--- a/tests/test_phonetic.py
+++ b/tests/test_phonetic.py
@@ -1,0 +1,43 @@
+"""Tests for phonetic name matching."""
+import pytest
+
+
+def test_phonetic_matches_transliteration_variants():
+    from africapep.pipeline.phonetic import phonetic_similarity
+
+    # Same name, different transliteration -> should sound identical
+    assert phonetic_similarity("Mohammed", "Muhammad") == 1.0
+    assert phonetic_similarity("Ahmed Mohammed", "Ahmad Muhammad") == 1.0
+    assert phonetic_similarity("Aboubacar", "Abubakar") == 1.0
+
+
+def test_phonetic_distinguishes_different_given_names():
+    from africapep.pipeline.phonetic import phonetic_similarity
+
+    # Same surname but clearly different given names should not be ~1.0
+    assert phonetic_similarity("Amadou Diallo", "Ousmane Diallo") < 1.0
+    assert phonetic_similarity("Mohammed Toure", "Ibrahim Toure") < 1.0
+
+
+def test_phonetic_is_token_order_independent():
+    from africapep.pipeline.phonetic import phonetic_similarity
+
+    assert phonetic_similarity("Mohammed Ali", "Ali Mohammed") == 1.0
+
+
+def test_phonetic_edge_cases_return_zero():
+    from africapep.pipeline.phonetic import phonetic_similarity
+
+    assert phonetic_similarity("", "Mohammed") == 0.0
+    assert phonetic_similarity("Mohammed", "") == 0.0
+    assert phonetic_similarity("", "") == 0.0
+    assert phonetic_similarity("---", "Mohammed") == 0.0
+
+
+def test_phonetic_keys_skip_blank():
+    from africapep.pipeline.phonetic import phonetic_keys
+
+    assert phonetic_keys("") == []
+    keys = phonetic_keys("Mohammed Ali")
+    assert len(keys) == 2
+    assert all(isinstance(k, tuple) and len(k) == 2 for k in keys)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,33 @@
+"""Tests for the name-matching scorer (components + backward-compat wrapper)."""
+
+
+def test_name_match_components_returns_both_signals():
+    from africapep.pipeline.scoring import name_match_components, NameMatchScore
+
+    score = name_match_components("Mohammed Ali", "Muhammad Ali")
+    assert isinstance(score, NameMatchScore)
+    assert 0.0 <= score.orthographic <= 1.0
+    assert 0.0 <= score.phonetic <= 1.0
+    # Transliteration: phonetic should be the stronger signal here
+    assert score.phonetic == 1.0
+    assert score.best == max(score.orthographic, score.phonetic)
+
+
+def test_hybrid_name_score_is_orthographic_only_unchanged():
+    """The legacy wrapper must equal the orthographic component exactly."""
+    from africapep.pipeline.scoring import hybrid_name_score, name_match_components
+
+    for a, b in [("Mohammed Ali", "Muhammad Ali"),
+                 ("Kwame Mensah", "Kwame Asante"),
+                 ("Nelson Mandela", "Robert Mugabe")]:
+        assert hybrid_name_score(a, b) == name_match_components(a, b).orthographic
+
+
+def test_best_never_below_orthographic():
+    from africapep.pipeline.scoring import name_match_components
+
+    for a, b in [("Ahmed Mohammed", "Ahmad Muhammad"),
+                 ("Jose Maria Neves", "Jose Maria Neves"),
+                 ("Ali Bongo", "Omar Bongo")]:
+        s = name_match_components(a, b)
+        assert s.best >= s.orthographic


### PR DESCRIPTION
Implements the design in `docs/superpowers/specs/2026-06-21-name-matching-eval-and-phonetic-design.md`.

## What & why

`hybrid_name_score` (pure orthographic edit distance) is the heart of **both** screening and entity resolution, with opposite error costs. It can't match transliteration variants (Mohammed/Muhammad) and there was **no way to measure match quality** — which is how the over-merge bug went unseen.

## Changes

**`scoring.py`** — `name_match_components()` returns separate **orthographic** + **phonetic** sub-scores. `hybrid_name_score()` retained unchanged as the orthographic score (backward compatible).

**`phonetic.py` (new)** — Metaphone (primary) + Soundex (alternate) token-set matching. Pure-Python via `jellyfish`, no new infra. (jellyfish 1.0.x has Metaphone, not Double Metaphone; Soundex approximates the alternate code.)

**Per-caller policy** (the key design point — one scorer, two risk postures):
- **Screening** (`screen.py`): recall-first, `best(orthographic, phonetic)`. *Note:* pg_trgm pre-filter still gates candidates; widening retrieval is deferred.
- **Resolution** (`resolver.py`): auto-merge requires strong **orthographic** match, OR **phonetic + corroboration** (DOB/position). Phonetic alone never merges. Compares **canonical full names only** — synthetic abbreviated variants ("A. Diallo" vs "O. Diallo") would otherwise re-introduce over-merging.

**Eval harness** (`scripts/eval_name_matching.py` + `tests/test_name_matching_eval.py`) — QID-grounded labeled pairs → precision/recall/F1, PR curve, merge-precision. Regression-guards with floors.

## Measured result (committed fixture)

| Threshold 0.90 | Recall | Precision |
|---|---|---|
| orthographic only | 0.833 | 0.909 |
| orthographic + phonetic | **1.000** | **0.923** |

Phonetic recovers transliteration variants *and* nudges precision up. The fixture includes "John Mensah"/"Joan Mensah" (different people) where **both** name signals alone false-merge — documenting why resolution requires corroboration.

## Tests
- New: `test_phonetic.py`, `test_scoring.py`, `test_name_matching_eval.py`, resolver over-merge tests (incl. the exact "Amadou/Ousmane Diallo + shared position" case the old gate merged).
- Full suite: **133 passed**.

## Deploy note
Adds `jellyfish==1.0.3` — first new runtime dep in this series, so deploy needs the wheel in the containers (pip install in-container or rebuild), not just `docker cp`.

## Out of scope (deferred, captured in spec)
Embeddings/pgvector/ANN (open-source self-hosted decided), Splink, neural transliteration, phonetic candidate-retrieval index.