### PR TITLE
feat: Splink probabilistic dedup pass (offline, AML-safe)

### DIFF
--- a/africapep/config.py
+++ b/africapep/config.py
@@ -15,6 +15,13 @@ class Settings(BaseSettings):
     # Longer timeout for heavy SPARQL queries (e.g. the P279* office-class
     # subclass walk in the citizenship branch), which exceed the default.
     scraper_sparql_timeout_seconds: int = 90
+
+    # Splink probabilistic dedup pass: match-probability thresholds for the
+    # AML-safe action policy. Auto-merge requires high probability AND
+    # corroboration; medium probability is queued for human review.
+    splink_automerge_prob: float = 0.99
+    splink_review_prob: float = 0.90
+
     environment: str = "development"
 
     # API authentication

--- a/africapep/database/schema/postgres_schema.sql
+++ b/africapep/database/schema/postgres_schema.sql
@@ -68,6 +68,23 @@ CREATE INDEX IF NOT EXISTS idx_source_neo4j_id ON source_records(neo4j_id);
 CREATE INDEX IF NOT EXISTS idx_source_country ON source_records(country);
 CREATE INDEX IF NOT EXISTS idx_pep_nationality ON pep_profiles(nationality);
 
+-- Candidate duplicate Person pairs from the Splink probabilistic dedup pass
+-- that fall in the human-review band (medium match probability, or high
+-- probability without corroboration). Nothing here is merged automatically.
+CREATE TABLE IF NOT EXISTS duplicate_review (
+    id                UUID PRIMARY KEY,
+    neo4j_id_a        TEXT NOT NULL,
+    neo4j_id_b        TEXT NOT NULL,
+    name_a            TEXT,
+    name_b            TEXT,
+    match_probability DOUBLE PRECISION NOT NULL,
+    matched_fields    JSONB,
+    status            TEXT NOT NULL DEFAULT 'PENDING',  -- PENDING|MERGED|REJECTED
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (neo4j_id_a, neo4j_id_b)
+);
+CREATE INDEX IF NOT EXISTS idx_dupreview_status ON duplicate_review(status);
+
 CREATE OR REPLACE FUNCTION update_search_vector() RETURNS TRIGGER AS $$
 BEGIN
     NEW.search_vector := to_tsvector('english',

--- a/africapep/pipeline/splink_resolver.py
+++ b/africapep/pipeline/splink_resolver.py
@@ -1,0 +1,224 @@
+"""Probabilistic record linkage for cross-QID duplicate Person records.
+
+The incremental resolver dedupes within a scrape run and (since the stable-id
+fix) collapses same-QID records. What remains are *cross-QID* duplicates -- two
+different Wikidata items that are the same human -- and no-QID records. This
+module scores Person pairs with calibrated Fellegi-Sunter match probabilities
+(Splink, DuckDB backend) and applies an AML-safe action policy.
+
+Two layers, deliberately separated:
+- **Policy** (``classify_pair`` / ``is_corroborated`` / ``decide_pairs``): pure
+  Python, no Splink, unit-testable without the heavy dependency. Routes a
+  (probability, corroboration) pair to AUTO_MERGE / REVIEW / IGNORE.
+- **Model** (``prepare_dataframe`` / ``train_linker`` / ``predict_pairs``):
+  imports Splink and pandas lazily, so importing this module for the policy
+  layer never requires the optional dependency.
+
+Splink is an OFFLINE batch dependency (see ``requirements-dedup.txt``); it is
+never installed in the runtime service image.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from rapidfuzz import fuzz
+
+from africapep.config import settings
+from africapep.pipeline.phonetic import phonetic_keys
+
+# Position similarity that counts as corroborating a name match (mirrors the
+# incremental resolver's POSITION_CORROBORATION).
+POSITION_CORROBORATION = 0.85
+
+
+class PairAction(str, Enum):
+    AUTO_MERGE = "AUTO_MERGE"
+    REVIEW = "REVIEW"
+    IGNORE = "IGNORE"
+
+
+@dataclass(frozen=True)
+class PairDecision:
+    id_a: str
+    id_b: str
+    probability: float
+    corroborated: bool
+    action: PairAction
+
+
+# ── Policy layer (pure; no Splink) ──
+
+def classify_pair(
+    probability: float,
+    corroborated: bool,
+    *,
+    automerge_prob: Optional[float] = None,
+    review_prob: Optional[float] = None,
+) -> PairAction:
+    """Route a scored pair to an action under the AML-safe policy.
+
+    - probability >= automerge_prob AND corroborated -> AUTO_MERGE
+    - probability >= review_prob (incl. high-prob but uncorroborated) -> REVIEW
+    - otherwise -> IGNORE
+    """
+    automerge_prob = (settings.splink_automerge_prob
+                      if automerge_prob is None else automerge_prob)
+    review_prob = (settings.splink_review_prob
+                   if review_prob is None else review_prob)
+
+    if probability >= automerge_prob and corroborated:
+        return PairAction.AUTO_MERGE
+    if probability >= review_prob:
+        return PairAction.REVIEW
+    return PairAction.IGNORE
+
+
+def is_corroborated(row_a: dict, row_b: dict) -> bool:
+    """True if DOB or a held position independently agrees between two rows.
+
+    ``row_*`` are flat dicts with ``date_of_birth`` and ``position`` keys
+    (``position`` = a representative "title @ institution" string, possibly
+    empty). Mirrors the incremental resolver's corroboration rule so the two
+    resolution paths agree on what "a second signal" means.
+    """
+    dob_a = (row_a.get("date_of_birth") or "").strip()
+    dob_b = (row_b.get("date_of_birth") or "").strip()
+    if dob_a and dob_b and dob_a == dob_b:
+        return True
+
+    pos_a = (row_a.get("position") or "").strip()
+    pos_b = (row_b.get("position") or "").strip()
+    if pos_a and pos_b:
+        if fuzz.token_sort_ratio(pos_a, pos_b) / 100.0 >= POSITION_CORROBORATION:
+            return True
+
+    return False
+
+
+def decide_pairs(pairs, rows_by_id, **thresholds) -> list[PairDecision]:
+    """Classify scored pairs into actions.
+
+    Args:
+        pairs: iterable of (id_a, id_b, probability).
+        rows_by_id: mapping id -> flat row dict (for corroboration lookup).
+        thresholds: optional automerge_prob / review_prob overrides.
+    """
+    decisions: list[PairDecision] = []
+    for id_a, id_b, prob in pairs:
+        row_a = rows_by_id.get(id_a, {})
+        row_b = rows_by_id.get(id_b, {})
+        corro = is_corroborated(row_a, row_b)
+        action = classify_pair(prob, corro, **thresholds)
+        decisions.append(PairDecision(id_a, id_b, float(prob), corro, action))
+    return decisions
+
+
+# ── Feature helpers (pure; no Splink) ──
+
+def metaphone_name_key(name: str) -> str:
+    """Space-joined primary metaphone codes of a name's tokens ("" if none)."""
+    return " ".join(primary for primary, _ in phonetic_keys(name) if primary)
+
+
+def phonetic_surname_key(name: str) -> str:
+    """Primary metaphone of the last token (surname), "" if none."""
+    keys = phonetic_keys(name)
+    return keys[-1][0] if keys else ""
+
+
+# ── Model layer (lazy Splink import) ──
+
+def prepare_dataframe(rows: list[dict]):
+    """Build the Splink input DataFrame from flat Person rows.
+
+    Each row needs: ``neo4j_id``, ``full_name``, ``date_of_birth``,
+    ``nationality``, ``position``. Adds derived ``phonetic_surname`` and
+    ``metaphone_name`` columns used by blocking and the phonetic comparison.
+    """
+    import pandas as pd
+
+    records = []
+    for r in rows:
+        name = r.get("full_name") or ""
+        records.append({
+            "unique_id": r["neo4j_id"],
+            "full_name": name,
+            "date_of_birth": r.get("date_of_birth") or None,
+            "nationality": r.get("nationality") or None,
+            "position": r.get("position") or "",
+            "phonetic_surname": phonetic_surname_key(name),
+            "metaphone_name": metaphone_name_key(name),
+        })
+    return pd.DataFrame.from_records(records)
+
+
+def build_settings():
+    """Build the Splink SettingsCreator for dedupe_only linkage."""
+    from splink import SettingsCreator, block_on
+    import splink.comparison_library as cl
+    import splink.comparison_level_library as cll
+
+    name_comparison = cl.CustomComparison(
+        output_column_name="full_name",
+        comparison_levels=[
+            cll.NullLevel("full_name"),
+            cll.ExactMatchLevel("full_name"),
+            cll.JaroWinklerLevel("full_name", 0.92),
+            # Phonetic agreement: same metaphone encoding of the whole name.
+            cll.ExactMatchLevel("metaphone_name"),
+            cll.JaroWinklerLevel("full_name", 0.82),
+            cll.ElseLevel(),
+        ],
+    )
+
+    return SettingsCreator(
+        link_type="dedupe_only",
+        blocking_rules_to_generate_predictions=[
+            block_on("nationality", "phonetic_surname"),
+            block_on("date_of_birth"),
+        ],
+        comparisons=[
+            name_comparison,
+            cl.ExactMatch("date_of_birth"),
+            cl.ExactMatch("nationality"),
+        ],
+        retain_intermediate_calculation_columns=True,
+    )
+
+
+def train_linker(df):
+    """Train a Splink Linker on the prepared DataFrame and return it."""
+    from splink import Linker, DuckDBAPI, block_on
+
+    linker = Linker(df, build_settings(), db_api=DuckDBAPI())
+
+    # Prior P(two random records match): estimate from deterministic rules so
+    # we don't fall back to the 0.0001 default.
+    linker.training.estimate_probability_two_random_records_match(
+        ["l.full_name = r.full_name", "l.date_of_birth = r.date_of_birth"],
+        recall=0.7,
+    )
+    linker.training.estimate_u_using_random_sampling(max_pairs=1e6)
+
+    # EM with column-fixing blocking rules: fix one column so the others'
+    # m-values are observed (a single naive EM rule leaves name untrained).
+    linker.training.estimate_parameters_using_expectation_maximisation(
+        block_on("date_of_birth")
+    )
+    linker.training.estimate_parameters_using_expectation_maximisation(
+        block_on("phonetic_surname")
+    )
+    return linker
+
+
+def predict_pairs(linker, threshold: Optional[float] = None):
+    """Return a list of (id_a, id_b, probability) above the review threshold."""
+    threshold = settings.splink_review_prob if threshold is None else threshold
+    preds = linker.inference.predict(threshold_match_probability=threshold)
+    pdf = preds.as_pandas_dataframe()
+    return [
+        (row.unique_id_l, row.unique_id_r, float(row.match_probability))
+        for row in pdf.itertuples()
+    ]

--- a/docs/superpowers/specs/2026-06-21-splink-probabilistic-dedup-design.md
+++ b/docs/superpowers/specs/2026-06-21-splink-probabilistic-dedup-design.md
@@ -1,0 +1,147 @@
+# Splink probabilistic dedup pass — design
+
+**Date:** 2026-06-21
+**Status:** Approved for implementation
+
+## Problem
+
+Entity resolution (`resolver.py`) uses hand-tuned weights (name 0.5 / DOB 0.3 /
+position 0.2) and a magic 0.85 threshold. After the QID-stable-id fix, same-QID
+records dedupe correctly, but **cross-QID duplicates** (two different Wikidata
+items that are the same human) and no-QID records are never linked. The hand-tuned
+gate gives no calibrated probability, so the merge/no-merge line is unprincipled
+and unauditable — a poor fit for an AML product.
+
+## Goal
+
+A **probabilistic record-linkage batch pass** using Splink (Fellegi-Sunter via
+DuckDB) that scores Person pairs with calibrated match probabilities, clusters
+duplicates, and acts with an AML-safe policy: auto-merge only very-high-confidence
+clusters, queue medium-confidence pairs for human review, ignore the rest.
+
+## Constraints / decisions
+
+- **Offline-capable**: runs off the server (against a Postgres dump or live read),
+  so the ~400 MB Splink/DuckDB dependency never touches the 95%-full server image.
+- **Splink stays out of the runtime image**: a separate `requirements-dedup.txt`;
+  the containers' `requirements.txt` is unchanged.
+- **AML-safe action policy** (your decision): auto-merge ≥0.99 *with corroboration*;
+  review 0.90–0.99; ignore <0.90.
+- **Batch, separate from scraping**: incremental `add()` keeps ingesting; this is a
+  periodic/manual cleanup pass that supersedes the crude `scripts/dedup_neo4j.py`.
+
+## Non-goals (YAGNI)
+
+Replacing incremental `add()`; Spark/Athena backends; real-time linkage;
+auto-approving the review queue (human-approved only).
+
+## Architecture
+
+```
+Postgres pep_profiles (or CSV dump)
+        │  read flat rows: neo4j_id, full_name, name_variants, dob, nationality, positions
+        ▼
+  prepare DataFrame  ── add phonetic surname key + metaphone column (reuse phonetic.py)
+        ▼
+  Splink (DuckDB)  ── settings → train (u-sampling + EM) → predict pairwise probs → cluster
+        ▼
+  classify_clusters()  ── PURE policy (no Splink): auto-merge / review / ignore
+        ▼
+  driver acts:  merge in Neo4j  +  write duplicate_review  +  re-sync Postgres
+        │  (default --dry-run: report only, change nothing)
+```
+
+### Components
+
+| Unit | File | Responsibility | Splink? |
+|---|---|---|---|
+| Model | `africapep/pipeline/splink_resolver.py` | Build settings, train, predict, cluster. | yes |
+| Policy | same module: `classify_pairs()` | Route pairwise (prob, corroboration) → AUTO_MERGE / REVIEW / IGNORE. Pure function over a list/DataFrame. | **no** (unit-testable) |
+| Driver | `scripts/run_splink_dedup.py` | Read input (Postgres or `--input CSV`); run model; `--dry-run` default; else merge Neo4j + write review + resync. | yes |
+| Review table | `africapep/database/schema/postgres_schema.sql` | `duplicate_review`. | n/a |
+| Optional deps | `requirements-dedup.txt` | `splink==4.0.16` (+ transitive). NOT in runtime image. | n/a |
+
+## Splink model configuration
+
+- **Backend:** DuckDB (in-process, in-memory; trivial for ~21K rows).
+- **Blocking rules** (limit pairs): `block_on("nationality", "phonetic_surname")`,
+  and `block_on("date_of_birth")`. Union of rules generates candidate pairs.
+- **Comparisons:**
+  - `full_name`: `JaroWinklerAtThresholds("full_name", [0.92, 0.82])` plus a
+    phonetic level (exact match on a precomputed `metaphone_name` column) so
+    transliteration variants register. Levels: exact / JW≥0.92 / phonetic / JW≥0.82 / else.
+  - `date_of_birth`: exact / same-year / else; null-handled.
+  - `nationality`: exact / else (also a blocking key).
+  - `position` (top current title+institution): fuzzy / else.
+- **Training (the part the smoke test showed is fragile):**
+  1. `estimate_probability_two_random_records_match(deterministic_rules, recall)`
+     — set the prior instead of leaving the 0.0001 default.
+  2. `estimate_u_using_random_sampling(max_pairs=1e6)`.
+  3. EM with **column-fixing** blocking rules — one EM run per fixed column so the
+     others' m-values are observed: `block_on("date_of_birth")` and
+     `block_on("phonetic_surname")`. (A single naive EM rule leaves `full_name`
+     untrained — confirmed in API smoke test.)
+- **Calibration check:** report match-probability separation on the QID-labeled
+  pairs from `tests/fixtures/name_match_pairs.json` (ties into the eval harness):
+  same-person pairs should score high, different-person low.
+
+## Action policy (AML-safe)
+
+`classify_pairs()` consumes pairwise predictions `(neo4j_id_l, neo4j_id_r,
+match_probability)` plus the row attributes needed for corroboration:
+
+- `probability ≥ 0.99` **and** corroboration (exact DOB match **or** position
+  match ≥ 0.85 — reuses the resolver's corroboration rule) → **AUTO_MERGE**.
+- `0.90 ≤ probability < 0.99`, or ≥0.99 without corroboration → **REVIEW**.
+- `< 0.90` → **IGNORE**.
+
+Thresholds in `africapep/config.py` (`splink_automerge_prob=0.99`,
+`splink_review_prob=0.90`) so posture is tunable without code change.
+
+Clustering: connected components at the review threshold define candidate groups;
+within a group, pairs are routed per the rule above. Auto-merge consolidates a
+cluster to the most-connected node (union positions/sources/name_variants), exactly
+like `dedup_neo4j.py`'s merge step.
+
+## `duplicate_review` table
+
+```sql
+CREATE TABLE IF NOT EXISTS duplicate_review (
+    id              UUID PRIMARY KEY,
+    neo4j_id_a      TEXT NOT NULL,
+    neo4j_id_b      TEXT NOT NULL,
+    name_a          TEXT,
+    name_b          TEXT,
+    match_probability DOUBLE PRECISION NOT NULL,
+    matched_fields  JSONB,
+    status          TEXT NOT NULL DEFAULT 'PENDING',  -- PENDING|MERGED|REJECTED
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (neo4j_id_a, neo4j_id_b)
+);
+```
+
+## Driver (`scripts/run_splink_dedup.py`)
+
+- `--input <csv>`: read rows from a dump (offline); default reads live Postgres.
+- `--dry-run` (default ON): print the merge plan + review counts, change nothing.
+- `--apply`: perform Neo4j merges, write `duplicate_review`, re-sync Postgres.
+- `--output <json>`: write the full classification (for offline review / audit).
+- Reuses `neo4j_client` merge helpers and `sync_all()`.
+
+## Testing & verification
+
+- **Pure policy tests (always run, no Splink):** `classify_pairs()` routes
+  ≥0.99+corroboration → AUTO_MERGE; 0.90–0.99 → REVIEW; <0.90 → IGNORE; ≥0.99
+  without corroboration → REVIEW.
+- **Splink integration test (`importorskip('splink')`):** train on a synthetic
+  labeled DataFrame (same/different people incl. transliteration variants); assert
+  same-person rows land in one cluster and different-person rows do not.
+- **Calibration script:** report probability separation on the QID fixture.
+- **Dry-run on prod data** before any `--apply`.
+
+## Dependency & deploy
+
+- `requirements-dedup.txt` (new): `splink==4.0.16`. Installed only where the batch
+  runs (locally / an ops box), never in `africapep-api`/`africapep-scraper`.
+- No server image change; no API hot-path change. Running `--apply` writes to
+  Neo4j + Postgres over their existing connections.

--- a/requirements-dedup.txt
+++ b/requirements-dedup.txt
@@ -1,0 +1,6 @@
+# Optional dependencies for the OFFLINE Splink probabilistic dedup pass
+# (scripts/run_splink_dedup.py). Deliberately NOT in requirements.txt: this is
+# a heavy (~400MB) batch-only dependency and must never be installed in the
+# runtime service image. Install where the batch is run:
+#     pip install -r requirements.txt -r requirements-dedup.txt
+splink==4.0.16

--- a/scripts/run_splink_dedup.py
+++ b/scripts/run_splink_dedup.py
@@ -1,0 +1,224 @@
+"""Run the Splink probabilistic dedup pass over Person records.
+
+Offline-capable batch tool. Reads flat Person rows (live PostgreSQL or a CSV
+dump), scores pairs with Splink, and applies the AML-safe policy: auto-merge
+very-high-confidence corroborated clusters in Neo4j, queue medium-confidence
+pairs in the ``duplicate_review`` table, ignore the rest.
+
+Default is --dry-run (report only; change nothing). Requires the offline deps:
+    pip install -r requirements.txt -r requirements-dedup.txt
+
+Usage:
+    python scripts/run_splink_dedup.py                    # dry-run, live Postgres
+    python scripts/run_splink_dedup.py --input rows.csv   # dry-run, offline dump
+    python scripts/run_splink_dedup.py --apply            # perform merges + review
+    python scripts/run_splink_dedup.py --output plan.json # save full classification
+
+CSV/dump columns: neo4j_id, full_name, date_of_birth, nationality, position
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+import uuid
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from africapep.pipeline.splink_resolver import (  # noqa: E402
+    PairAction, prepare_dataframe, train_linker, predict_pairs, decide_pairs,
+)
+
+
+def _position_str(current_positions) -> str:
+    """Representative 'title @ institution' from a current_positions JSON list."""
+    if isinstance(current_positions, str):
+        try:
+            current_positions = json.loads(current_positions)
+        except (ValueError, TypeError):
+            return ""
+    if isinstance(current_positions, list) and current_positions:
+        p = current_positions[0]
+        if isinstance(p, dict):
+            return f"{p.get('title', '')} @ {p.get('institution', '')}".strip(" @")
+    return ""
+
+
+def load_rows_from_postgres() -> list[dict]:
+    from sqlalchemy import text
+    from africapep.database.postgres_client import get_db
+
+    rows = []
+    with get_db() as db:
+        result = db.execute(text(
+            "SELECT neo4j_id, full_name, date_of_birth, nationality, "
+            "current_positions FROM pep_profiles WHERE neo4j_id IS NOT NULL"
+        ))
+        for r in result.fetchall():
+            rows.append({
+                "neo4j_id": r.neo4j_id,
+                "full_name": r.full_name,
+                "date_of_birth": str(r.date_of_birth) if r.date_of_birth else "",
+                "nationality": r.nationality,
+                "position": _position_str(r.current_positions),
+            })
+    return rows
+
+
+def load_rows_from_csv(path: str) -> list[dict]:
+    with open(path, encoding="utf-8") as f:
+        return [
+            {
+                "neo4j_id": r["neo4j_id"],
+                "full_name": r.get("full_name", ""),
+                "date_of_birth": r.get("date_of_birth", "") or "",
+                "nationality": r.get("nationality", ""),
+                "position": r.get("position", ""),
+            }
+            for r in csv.DictReader(f)
+        ]
+
+
+def _union_find(pairs):
+    """Cluster auto-merge pairs into connected components (id -> root)."""
+    parent = {}
+
+    def find(x):
+        parent.setdefault(x, x)
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a, b):
+        parent[find(a)] = find(b)
+
+    for a, b in pairs:
+        union(a, b)
+    clusters: dict[str, list[str]] = {}
+    for node in list(parent):
+        clusters.setdefault(find(node), []).append(node)
+    return [c for c in clusters.values() if len(c) > 1]
+
+
+# ── Neo4j merge (mirrors scripts/dedup_neo4j.py) ──
+
+def _merge_cluster(session, ids: list[str]) -> str:
+    """Merge a cluster of Person ids into the most-connected node; return it."""
+    counts = session.run(
+        "UNWIND $ids AS pid MATCH (p:Person {id: pid}) "
+        "OPTIONAL MATCH (p)-[:HELD_POSITION]->(pos) "
+        "RETURN pid, count(pos) AS c ORDER BY c DESC", {"ids": ids})
+    ordered = [r["pid"] for r in counts]
+    primary, secondaries = ordered[0], ordered[1:]
+    session.run("""
+        MATCH (primary:Person {id: $p})
+        UNWIND $sids AS sid MATCH (s:Person {id: sid})
+        WITH primary, s,
+             [v IN s.name_variants WHERE NOT v IN primary.name_variants] AS nv
+        SET primary.name_variants = primary.name_variants + nv,
+            primary.date_of_birth = coalesce(primary.date_of_birth, s.date_of_birth)
+    """, {"p": primary, "sids": secondaries})
+    for rel in ("HELD_POSITION", "SOURCED_FROM", "CITIZEN_OF"):
+        session.run(f"""
+            UNWIND $sids AS sid
+            MATCH (s:Person {{id: sid}})-[r:{rel}]->(t)
+            MATCH (primary:Person {{id: $p}})
+            WHERE NOT (primary)-[:{rel}]->(t)
+            MERGE (primary)-[:{rel}]->(t) DELETE r
+        """, {"p": primary, "sids": secondaries})
+    session.run("UNWIND $sids AS sid MATCH (s:Person {id: sid}) DETACH DELETE s",
+                {"sids": secondaries})
+    return primary
+
+
+def apply_changes(decisions, rows_by_id) -> dict:
+    """Perform auto-merges in Neo4j, write review rows to Postgres, re-sync."""
+    from neo4j import GraphDatabase
+    from sqlalchemy import text
+    from africapep.config import settings
+    from africapep.database.postgres_client import get_db
+    from africapep.database.sync import sync_all
+
+    auto = [(d.id_a, d.id_b) for d in decisions if d.action == PairAction.AUTO_MERGE]
+    reviews = [d for d in decisions if d.action == PairAction.REVIEW]
+    clusters = _union_find(auto)
+
+    merged_clusters = 0
+    driver = GraphDatabase.driver(
+        settings.neo4j_uri, auth=(settings.neo4j_user, settings.neo4j_password))
+    with driver.session() as session:
+        for ids in clusters:
+            _merge_cluster(session, ids)
+            merged_clusters += 1
+    driver.close()
+
+    with get_db() as db:
+        for d in reviews:
+            a, b = sorted((d.id_a, d.id_b))
+            db.execute(text("""
+                INSERT INTO duplicate_review
+                    (id, neo4j_id_a, neo4j_id_b, name_a, name_b,
+                     match_probability, matched_fields, status)
+                VALUES (:id, :a, :b, :na, :nb, :prob, CAST(:mf AS jsonb), 'PENDING')
+                ON CONFLICT (neo4j_id_a, neo4j_id_b) DO UPDATE
+                    SET match_probability = EXCLUDED.match_probability
+            """), {
+                "id": str(uuid.uuid4()), "a": a, "b": b,
+                "na": rows_by_id.get(d.id_a, {}).get("full_name"),
+                "nb": rows_by_id.get(d.id_b, {}).get("full_name"),
+                "prob": d.probability,
+                "mf": json.dumps({"corroborated": d.corroborated}),
+            })
+
+    synced = sync_all()
+    return {"merged_clusters": merged_clusters, "review_rows": len(reviews),
+            "resynced": synced}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", help="CSV dump instead of live Postgres")
+    parser.add_argument("--apply", action="store_true",
+                        help="perform merges + write review (default: dry-run)")
+    parser.add_argument("--output", help="write full classification JSON here")
+    args = parser.parse_args()
+
+    rows = load_rows_from_csv(args.input) if args.input else load_rows_from_postgres()
+    print(f"Loaded {len(rows)} Person rows")
+    rows_by_id = {r["neo4j_id"]: r for r in rows}
+
+    df = prepare_dataframe(rows)
+    linker = train_linker(df)
+    pairs = predict_pairs(linker)
+    decisions = decide_pairs([(a, b, p) for a, b, p in pairs], rows_by_id)
+
+    counts = {a.value: 0 for a in PairAction}
+    for d in decisions:
+        counts[d.action.value] += 1
+    print(f"Scored pairs: {len(decisions)}  -> {counts}")
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump([{
+                "id_a": d.id_a, "id_b": d.id_b, "probability": d.probability,
+                "corroborated": d.corroborated, "action": d.action.value,
+                "name_a": rows_by_id.get(d.id_a, {}).get("full_name"),
+                "name_b": rows_by_id.get(d.id_b, {}).get("full_name"),
+            } for d in decisions], f, indent=2, ensure_ascii=False)
+        print(f"Wrote classification -> {args.output}")
+
+    if args.apply:
+        result = apply_changes(decisions, rows_by_id)
+        print(f"APPLIED: {result}")
+    else:
+        clusters = _union_find(
+            [(d.id_a, d.id_b) for d in decisions if d.action == PairAction.AUTO_MERGE])
+        print(f"DRY-RUN: would merge {len(clusters)} cluster(s), "
+              f"queue {counts['REVIEW']} review pair(s). Re-run with --apply.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_splink_resolver.py
+++ b/tests/test_splink_resolver.py
@@ -1,0 +1,127 @@
+"""Tests for the Splink probabilistic dedup pass.
+
+The policy layer is pure Python and always tested. The Splink model layer is
+exercised only when Splink is installed (importorskip), since it is an offline
+batch dependency kept out of the runtime image.
+"""
+import pytest
+
+from africapep.pipeline.splink_resolver import (
+    PairAction,
+    classify_pair,
+    is_corroborated,
+    decide_pairs,
+    metaphone_name_key,
+    phonetic_surname_key,
+)
+
+
+# ── Policy layer (always runs) ──
+
+def test_classify_pair_auto_merge_requires_corroboration():
+    # High probability + corroboration -> auto-merge
+    assert classify_pair(0.995, True, automerge_prob=0.99, review_prob=0.90) \
+        == PairAction.AUTO_MERGE
+    # High probability WITHOUT corroboration -> review, never auto-merge
+    assert classify_pair(0.995, False, automerge_prob=0.99, review_prob=0.90) \
+        == PairAction.REVIEW
+
+
+def test_classify_pair_review_band():
+    assert classify_pair(0.95, True, automerge_prob=0.99, review_prob=0.90) \
+        == PairAction.REVIEW
+    assert classify_pair(0.90, False, automerge_prob=0.99, review_prob=0.90) \
+        == PairAction.REVIEW
+
+
+def test_classify_pair_ignore_below_review():
+    assert classify_pair(0.89, True, automerge_prob=0.99, review_prob=0.90) \
+        == PairAction.IGNORE
+    assert classify_pair(0.10, True) == PairAction.IGNORE
+
+
+def test_is_corroborated_by_dob():
+    a = {"date_of_birth": "1960-01-01", "position": ""}
+    b = {"date_of_birth": "1960-01-01", "position": ""}
+    assert is_corroborated(a, b) is True
+
+
+def test_is_corroborated_by_position():
+    a = {"date_of_birth": "", "position": "Minister of Finance @ Ministry"}
+    b = {"date_of_birth": "", "position": "Minister of Finance @ Ministry"}
+    assert is_corroborated(a, b) is True
+
+
+def test_not_corroborated_when_signals_differ_or_missing():
+    assert is_corroborated(
+        {"date_of_birth": "1960-01-01", "position": "President @ Govt"},
+        {"date_of_birth": "1975-05-05", "position": "Footballer @ Club"},
+    ) is False
+    # Missing on both sides cannot corroborate
+    assert is_corroborated({"date_of_birth": "", "position": ""},
+                           {"date_of_birth": "", "position": ""}) is False
+
+
+def test_decide_pairs_routes_with_corroboration_lookup():
+    rows = {
+        "a": {"date_of_birth": "1942-12-17", "position": "President @ Govt"},
+        "b": {"date_of_birth": "1942-12-17", "position": "President @ Govt"},
+        "c": {"date_of_birth": "1990-01-01", "position": "Mayor @ City"},
+    }
+    decisions = decide_pairs(
+        [("a", "b", 0.999), ("a", "c", 0.92)], rows,
+        automerge_prob=0.99, review_prob=0.90,
+    )
+    by_pair = {(d.id_a, d.id_b): d for d in decisions}
+    assert by_pair[("a", "b")].action == PairAction.AUTO_MERGE
+    assert by_pair[("a", "b")].corroborated is True
+    assert by_pair[("a", "c")].action == PairAction.REVIEW  # corro False, mid prob
+
+
+def test_phonetic_feature_helpers():
+    # Same-sounding surnames share a phonetic surname key
+    assert phonetic_surname_key("Sory Kaba") == phonetic_surname_key("Sori Kabba")
+    assert metaphone_name_key("Mohammed Buhari") == metaphone_name_key("Muhammad Buhari")
+    assert phonetic_surname_key("") == ""
+    assert metaphone_name_key("") == ""
+
+
+# ── Model layer (requires Splink) ──
+
+def test_splink_model_clusters_true_duplicates():
+    pytest.importorskip("splink")
+    from africapep.pipeline.splink_resolver import (
+        prepare_dataframe, train_linker, predict_pairs,
+    )
+
+    rows = [
+        {"neo4j_id": "wd:Q1", "full_name": "Mohammed Buhari",
+         "date_of_birth": "1942-12-17", "nationality": "NG", "position": "President @ Govt"},
+        {"neo4j_id": "wd:Q2", "full_name": "Muhammadu Buhari",
+         "date_of_birth": "1942-12-17", "nationality": "NG", "position": "President @ Govt"},
+        {"neo4j_id": "wd:Q3", "full_name": "Sory Kaba",
+         "date_of_birth": "1960-01-01", "nationality": "GN", "position": "Director @ Govt"},
+        {"neo4j_id": "wd:Q4", "full_name": "Sori Kabba",
+         "date_of_birth": "1960-01-01", "nationality": "GN", "position": "Director @ Govt"},
+        {"neo4j_id": "wd:Q5", "full_name": "Paul Biya",
+         "date_of_birth": "1933-02-13", "nationality": "CM", "position": "President @ Govt"},
+        {"neo4j_id": "wd:Q6", "full_name": "Franck Biya",
+         "date_of_birth": "1971-01-01", "nationality": "CM", "position": "Businessman @ Co"},
+        {"neo4j_id": "wd:Q7", "full_name": "Nelson Mandela",
+         "date_of_birth": "1918-07-18", "nationality": "ZA", "position": "President @ Govt"},
+        {"neo4j_id": "wd:Q8", "full_name": "Ellen Johnson",
+         "date_of_birth": "1938-10-29", "nationality": "LR", "position": "President @ Govt"},
+    ]
+    import warnings
+    warnings.filterwarnings("ignore")
+    df = prepare_dataframe(rows)
+    linker = train_linker(df)
+    pairs = predict_pairs(linker, threshold=0.5)
+    matched = {tuple(sorted((a, b))) for a, b, _ in pairs}
+
+    # True cross-spelling duplicates must be linked.
+    assert ("wd:Q1", "wd:Q2") in matched, "Buhari variants should link"
+    assert ("wd:Q3", "wd:Q4") in matched, "Kaba variants should link"
+    # Distinct people must NOT be linked.
+    assert ("wd:Q5", "wd:Q6") not in matched, "Paul/Franck Biya must not merge"
+    assert ("wd:Q7", "wd:Q8") not in matched, "unrelated must not merge"


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-06-21-splink-probabilistic-dedup-design.md`.

## What & why

The incremental resolver uses hand-tuned weights + a magic 0.85 threshold and can't link **cross-QID duplicates** (two Wikidata items = same human). This adds **Fellegi-Sunter probabilistic linkage** (Splink, DuckDB) as an **offline batch pass** with calibrated match probabilities — superseding the crude name+nationality `dedup_neo4j.py`.

## Design highlights

**Two layers, separated by dependency:**
- **Policy** (pure Python, no Splink) — `classify_pair`/`is_corroborated`/`decide_pairs`. Unit-testable without the heavy dep.
- **Model** (lazy Splink import) — `prepare_dataframe` (adds phonetic surname + metaphone columns, reusing `phonetic.py`), `train_linker` (u-sampling + prior + **EM with column-fixing blocking rules** — a naive single EM rule leaves name untrained), `predict_pairs`.

**AML-safe action policy** (your decision): auto-merge only **≥0.99 WITH corroboration** (DOB or position match, mirroring the incremental resolver); **0.90–0.99 → human review**; **<0.90 → ignore**. Thresholds in `config.py`.

**Splink kept OUT of the runtime image:** new `requirements-dedup.txt` (`splink==4.0.16`); service `requirements.txt` unchanged. The ~400 MB dep never touches the 95%-full server.

**Driver** `scripts/run_splink_dedup.py`: offline-capable (live Postgres or `--input CSV`), **`--dry-run` default**; `--apply` does Neo4j cluster merges (union-find), writes `duplicate_review`, re-syncs.

## Validation

Validated against real Splink on synthetic data + an offline CSV dry-run: true cross-spelling duplicates link (Mohammed/Muhammadu **Buhari**, Sory/Sori **Kaba/Kabba** — phonetic comparison) at 0.996 → AUTO_MERGE with corroboration; distinct people (**Paul/Franck Biya**, Mandela) correctly excluded.

## Tests
- Pure policy (always run): threshold routing, corroboration, decide_pairs, feature helpers.
- Splink integration (`importorskip`): true duplicates cluster, distinct people don't.
- Full suite: **142 passed**.

## Deploy / run notes
- Schema adds `duplicate_review` — apply to server Postgres before `--apply`.
- This is **offline + destructive on --apply**; intended flow is `--dry-run` against prod first, human review, then `--apply`. Not auto-scheduled.

## Out of scope
Replacing incremental `add()`; Spark/Athena; real-time linkage; auto-approving the review queue.