### PR TITLE
fix: repair CI and re-enable entity resolution tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/PatrickAttankurugu/AfricaPEP/issues"
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
-addopts = "--cov=africapep --cov-report=term-missing --ignore=tests/test_entity_resolution.py"
+addopts = "--cov=africapep --cov-report=term-missing"
 markers = [
     "integration: marks tests requiring database connections",
     "slow: marks slow-running tests",

--- a/tests/test_phonetic.py
+++ b/tests/test_phonetic.py
@@ -1,5 +1,4 @@
 """Tests for phonetic name matching."""
-import pytest
 
 
 def test_phonetic_matches_transliteration_variants():

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -324,7 +324,7 @@ def test_wikidata_scraper_scrape_with_mock():
     assert records[1].full_name == "Godswill Akpabio"
     assert records[1].extra_fields["start_date"] == "2023-06-13"
     assert records[1].extra_fields["is_current"] is True
-    
+
     # Verify extraction of Date of Birth (P569) from the mock SPARQL response
     assert records[1].extra_fields["date_of_birth"] == "1962-12-09"
 


### PR DESCRIPTION
Fixes the two ruff errors that have kept CI red on every push since June, and removes the stale `--ignore=tests/test_entity_resolution.py` from `pyproject.toml`. All 20 previously-excluded tests pass, and entity resolution is exactly the area where the last several regressions happened, so the default suite must cover it.

Local verification: `ruff check` clean, 144 tests passing.