### PR TITLE
fix: derive Position/Organisation node ids from content to stop per-run duplication

### DIFF
--- a/africapep/database/sync.py
+++ b/africapep/database/sync.py
@@ -25,7 +25,7 @@ def sync_all():
     MATCH (p:Person)
     OPTIONAL MATCH (p)-[hp:HELD_POSITION]->(pos:Position)
     WHERE hp.is_current = true
-    WITH p, collect({
+    WITH p, collect(DISTINCT {
         title: pos.title,
         institution: pos.institution,
         country: pos.country,
@@ -59,8 +59,19 @@ def sync_all():
             is_active = person.get("is_active_pep", True)
             positions = person.get("current_positions") or []
 
-            # Filter out empty position dicts
+            # Filter out empty position dicts, then drop duplicates while
+            # keeping order (duplicate Position nodes existed in the graph
+            # before ids became content-derived).
             positions = [p for p in positions if p.get("title")]
+            seen_positions = set()
+            unique_positions = []
+            for p in positions:
+                key = (p.get("title"), p.get("institution"),
+                       p.get("country"), p.get("branch"))
+                if key not in seen_positions:
+                    seen_positions.add(key)
+                    unique_positions.append(p)
+            positions = unique_positions
 
             now = datetime.now(timezone.utc).isoformat()
             db.execute(text("""

--- a/africapep/pipeline/resolver.py
+++ b/africapep/pipeline/resolver.py
@@ -41,6 +41,16 @@ NAME_WEIGHT = 0.5
 DOB_WEIGHT = 0.3
 POSITION_WEIGHT = 0.2
 
+# Namespace for deriving stable Position/Organisation ids from their content.
+# Random ids here made MERGE behave like CREATE, so every pipeline run minted
+# duplicate nodes (same bug class as the Person QID fix in #24).
+_CONTENT_ID_NAMESPACE = uuid.UUID("7f3d9b2a-4c81-4f6e-9d25-8a1b3c5e7f90")
+
+
+def _content_id(*parts: Optional[str]) -> str:
+    key = "|".join((p or "").strip().lower() for p in parts)
+    return str(uuid.uuid5(_CONTENT_ID_NAMESPACE, key))
+
 
 @dataclass
 class ResolvedEntity:
@@ -382,7 +392,13 @@ class EntityResolver:
             })
 
             for pos in entity.positions:
-                pos_id = str(uuid.uuid4())
+                pos_id = _content_id(
+                    "position",
+                    pos.get("title", ""),
+                    pos.get("institution", ""),
+                    pos.get("country", entity.nationality),
+                    pos.get("branch", "EXECUTIVE"),
+                )
                 position_rows.append({
                     "id": pos_id,
                     "title": pos.get("title", ""),
@@ -402,8 +418,8 @@ class EntityResolver:
                 })
 
                 if pos.get("institution"):
-                    org_id = str(uuid.uuid4())
                     country = pos.get("country", entity.nationality)
+                    org_id = _content_id("organisation", pos["institution"], country)
                     org_rows.append({
                         "id": org_id,
                         "name": pos["institution"],
@@ -435,6 +451,11 @@ class EntityResolver:
                     "pid": entity.id,
                     "sid": src_id,
                 })
+
+        # Content-derived ids repeat when entities share a position or
+        # organisation; write each node once per flush.
+        position_rows = list({row["id"]: row for row in position_rows}.values())
+        org_rows = list({row["id"]: row for row in org_rows}.values())
 
         # ── Batch write all collected data ──
         written = len(person_rows)

--- a/tests/test_entity_resolution.py
+++ b/tests/test_entity_resolution.py
@@ -256,3 +256,34 @@ class TestScoringLogic:
         r2 = _make_record("Ama Bawumia")
         score = resolver._compute_score(r2, existing)
         assert score < 0.70, f"Different names should score low, got {score}"
+
+
+class TestContentDerivedNodeIds:
+    """Position/Organisation ids must be stable across pipeline runs so Neo4j
+    MERGE upserts onto existing nodes instead of minting duplicates."""
+
+    def test_same_position_content_same_id(self):
+        from africapep.pipeline.resolver import _content_id
+
+        a = _content_id("position", "President", "Government of Chad", "TD", "EXECUTIVE")
+        b = _content_id("position", "President", "Government of Chad", "TD", "EXECUTIVE")
+        assert a == b
+
+    def test_id_normalises_case_and_whitespace(self):
+        from africapep.pipeline.resolver import _content_id
+
+        a = _content_id("position", "President", "Government of Chad", "TD", "EXECUTIVE")
+        b = _content_id("position", " president ", "GOVERNMENT OF CHAD", "td", "executive")
+        assert a == b
+
+    def test_different_content_different_id(self):
+        from africapep.pipeline.resolver import _content_id
+
+        a = _content_id("position", "President", "Government of Chad", "TD", "EXECUTIVE")
+        b = _content_id("position", "Minister of Finance", "Government of Chad", "TD", "EXECUTIVE")
+        assert a != b
+
+    def test_none_parts_handled(self):
+        from africapep.pipeline.resolver import _content_id
+
+        assert _content_id("organisation", None, None) == _content_id("organisation", "", "")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -130,6 +130,27 @@ class TestSyncAllMissingFields:
 
     @patch("africapep.database.sync.get_db")
     @patch("africapep.database.sync.neo4j_client")
+    def test_duplicate_positions_collapsed(self, mock_neo4j, mock_get_db):
+        person = sample_person_neo4j()
+        duplicate = {"title": "Minister of Public Health", "institution": "Govt",
+                     "country": "TD", "branch": "EXECUTIVE"}
+        other = {"title": "Minister of Finance", "institution": "Govt",
+                 "country": "TD", "branch": "EXECUTIVE"}
+        person["current_positions"] = [duplicate, dict(duplicate), other, dict(duplicate)]
+        mock_neo4j.run.side_effect = [[person], []]
+
+        db = MagicMock()
+        db.__enter__ = MagicMock(return_value=db)
+        db.__exit__ = MagicMock(return_value=False)
+        mock_get_db.return_value = db
+
+        assert sync_all() == 1
+        call_params = db.execute.call_args[0][1]
+        positions = json.loads(call_params["positions"])
+        assert positions == [duplicate, other]
+
+    @patch("africapep.database.sync.get_db")
+    @patch("africapep.database.sync.neo4j_client")
     def test_positions_without_title_filtered(self, mock_neo4j, mock_get_db):
         person = sample_person_neo4j()
         person["current_positions"] = [


### PR DESCRIPTION
Position and Organisation nodes were duplicated on every scraper re-run because their ids were not stable across runs. This derives node ids deterministically from content (uuid5 over the identifying fields), matching the approach already used for Person nodes in #24.

Includes new regression tests in test_entity_resolution.py and test_sync.py (which now run in CI as of #31).