### PR TITLE
chore: reconcile public claims, harden ops security, add contributor growth docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/country_validation.md
+++ b/.github/ISSUE_TEMPLATE/country_validation.md
@@ -1,0 +1,30 @@
+---
+name: Country Data Validation
+about: Validate PEP data quality for a specific country (no coding required)
+title: "[VALIDATE] Data quality review for {country}"
+labels: country-data, help wanted
+assignees: ''
+---
+
+**Country:** [e.g., Nigeria]
+**Your background:** [e.g., compliance officer, journalist, researcher, resident with local knowledge]
+
+## What to check
+
+Use the live demo at https://pep.patrickaiafrica.com (or the API directly, see [docs/API.md](../../docs/API.md)) and review the data for this country against your knowledge of its political landscape.
+
+- [ ] **Coverage gaps:** Are any current senior officials missing? (President, VP, ministers, MPs, senior judges, central bank leadership, military chiefs)
+- [ ] **Stale records:** Are any listed officials out of office but still marked active?
+- [ ] **Wrong tiers:** Are any officials classified in the wrong FATF tier? (Tier 1: heads of state, ministers, chief justice; Tier 2: MPs, judges, ambassadors; Tier 3: local officials)
+- [ ] **Name issues:** Are common local spellings or transliterations of names missing, causing screening misses?
+- [ ] **Duplicates:** Does the same person appear as two separate profiles?
+
+## Findings
+
+| # | Profile or missing person | Problem | Evidence (URL) |
+|---|---------------------------|---------|----------------|
+| 1 |                           |         |                |
+
+## Notes
+
+Anything else about this country's data quality worth recording.

--- a/CONTRIBUTING-DATA.md
+++ b/CONTRIBUTING-DATA.md
@@ -1,0 +1,40 @@
+# Contributing Without Writing Code
+
+AfricaPEP's hardest problems are not software problems. They are data problems: is the Nigeria data complete, are Ghana's judges in the right FATF tier, does a common Hausa spelling of a governor's name actually match? Answering those questions requires knowledge of a country's political landscape, not Python.
+
+If you are a compliance officer, AML analyst, journalist, researcher, or simply someone who knows a country's politics well, this guide is for you.
+
+## Ways to contribute
+
+### 1. Validate a country's data (highest impact)
+
+Pick a country you know. Open a [Country Data Validation issue](https://github.com/PatrickAttankurugu/AfricaPEP/issues/new?template=country_validation.md) and work through the checklist: coverage gaps, stale records, wrong tiers, missing name variants, duplicates.
+
+You can do the whole review from the live demo at [pep.patrickaiafrica.com](https://pep.patrickaiafrica.com), no setup required. Search for officials you know should be there, screen names with common local spellings, and record what is wrong or missing.
+
+Every finding should link to public evidence: a government website, gazette, reputable news source, or official register.
+
+### 2. Improve FATF tier classification
+
+Tier assignment is keyword-based and misses country-specific titles (see issue [#3](https://github.com/PatrickAttankurugu/AfricaPEP/issues/3)). If you know that, for example, a "Regional Chief Executive" in one country carries Tier 1 influence while the same title elsewhere is Tier 3, that knowledge is a contribution. Comment on the issue or open a new one.
+
+### 3. Propose national data sources
+
+Wikidata is the current sole source. If you know an official register that lists office-holders for your country (electoral commission, government gazette, judiciary site, parliament register), propose it with a [New Data Source issue](https://github.com/PatrickAttankurugu/AfricaPEP/issues/new?template=new_scraper.md). You do not need to build the scraper; documenting the source, its URL structure, and its update cadence is the hard part.
+
+### 4. Review screening quality
+
+Run real-world style screenings (with public figures' names, never real customer data) and report false positives and false negatives. Name matching across African languages and transliteration systems is an open problem here (issues [#2](https://github.com/PatrickAttankurugu/AfricaPEP/issues/2), [#8](https://github.com/PatrickAttankurugu/AfricaPEP/issues/8), [#12](https://github.com/PatrickAttankurugu/AfricaPEP/issues/12)).
+
+## Ground rules
+
+- Every claim needs a public, citable source. "I know this person" is a lead; a gazette entry is evidence.
+- Never submit non-public personal data. This project only records what is already public about public officials.
+- One country per validation issue, so findings stay reviewable.
+- Be factual and neutral in describing officials. This is a compliance dataset, not a commentary platform.
+
+## Recognition
+
+Data validators are credited in release notes alongside code contributors. Sustained validation work for a country effectively makes you that country's data steward, and we will say so publicly.
+
+Questions? Open a [Discussion](https://github.com/PatrickAttankurugu/AfricaPEP/discussions).

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Docker](https://img.shields.io/badge/docker-compose-blue.svg)](https://docs.docker.com/compose/)
-[![Tests](https://img.shields.io/badge/tests-79%20passing-brightgreen.svg)](#running-tests)
+[![Tests](https://img.shields.io/badge/tests-170%2B-brightgreen.svg)](#running-tests)
 [![Countries](https://img.shields.io/badge/countries-54-orange.svg)](#database-coverage)
-[![PEPs](https://img.shields.io/badge/PEP%20profiles-32%2C476-purple.svg)](#database-coverage)
+[![PEPs](https://img.shields.io/badge/PEP%20profiles-34%2C000%2B-purple.svg)](#database-coverage)
 [![Contributing](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 A production-grade, open-source PEP (Politically Exposed Persons) database covering **all 54 African Union member states**. Built for KYC/AML compliance teams who need reliable PEP screening without expensive third-party data subscriptions.
@@ -15,7 +15,7 @@ A production-grade, open-source PEP (Politically Exposed Persons) database cover
 
 ## Why AfricaPEP?
 
-- **32,000+ verified PEP profiles** — Sourced from Wikidata's community-maintained, referenced database
+- **34,000+ verified PEP profiles** — Sourced from Wikidata's community-maintained, referenced database
 - **Complete African coverage** — All 54 AU member states
 - **Free and open source** — No licensing fees, no API quotas, no vendor lock-in
 - **Graph-powered** — Neo4j captures PEP relationships, family ties, and political networks
@@ -43,13 +43,15 @@ The scraper queries Wikidata's public SPARQL endpoint for all persons who hold o
 
 **Re-seeding pulls fresh data** — run `python -m africapep.database.seed` anytime to get the latest from Wikidata.
 
+Wikidata is currently the sole data source, queried through one parameterized SPARQL scraper that runs per country. The scraper framework (rate limiting, retries, per-source isolation) is built to support national sources such as government gazettes, electoral commissions, and judiciary websites: these are open contribution opportunities, tracked as [`new-scraper` issues](https://github.com/PatrickAttankurugu/AfricaPEP/issues?q=is%3Aissue+is%3Aopen+label%3Anew-scraper).
+
 ## Architecture
 
 ```
 +-------------------------------------------------------------+
 |                        DATA SOURCE                          |
 |              Wikidata SPARQL Endpoint                       |
-|    Community-verified | Referenced | 33,000+ African PEPs  |
+|    Community-verified | Referenced | 34,000+ African PEPs  |
 +-------------------------------------------------------------+
                              |
                              v
@@ -109,7 +111,7 @@ git clone https://github.com/PatrickAttankurugu/AfricaPEP.git && cd AfricaPEP
 # 2. Setup the environment and start services
 make setup
 
-# 3. Seed with live PEP data from Wikidata (32,000+ profiles)
+# 3. Seed with live PEP data from Wikidata (34,000+ profiles)
 make seed
 
 # 4. Success! API is live at http://localhost:8000
@@ -270,7 +272,7 @@ africapep/
 ├── pipeline/       # NLP normaliser, FATF classifier, entity resolver
 ├── scraper/        # BaseScraper + WikidataScraper (SPARQL-based)
 └── scheduler/      # APScheduler job definitions
-tests/              # 79 tests covering scraper, pipeline, and API
+tests/              # 170+ tests covering scraper, pipeline, and API
 docs/               # Design documents and plans
 ```
 
@@ -297,13 +299,16 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ### Good first issues
 
-New to the project? Look for issues labeled [`good first issue`](https://github.com/PatrickAttankurugu/AfricaPEP/labels/good%20first%20issue):
+New to the project? Look for issues labeled [`good first issue`](https://github.com/PatrickAttankurugu/AfricaPEP/labels/good%20first%20issue). Currently open:
 
-- Add date of birth extraction from Wikidata SPARQL
-- Improve FATF tier classification for judiciary roles
-- Add French/Arabic name transliteration support
-- Write tests for the sync module
-- Add API response pagination headers
+- Add French name transliteration support (#2)
+- Improve FATF tier classification for judiciary roles (#3)
+- Add party affiliation extraction from Wikidata (#5)
+- Add AU, ECOWAS, SADC, and EAC officials as regional PEPs (#7)
+- Add Arabic name transliteration for North African countries (#8)
+- Add Docker Compose one-command local setup (#14)
+
+You do not need to write code to contribute: compliance professionals can validate country data quality (#15). See [CONTRIBUTING-DATA.md](CONTRIBUTING-DATA.md).
 
 ### Other ways to contribute
 
@@ -325,6 +330,7 @@ New to the project? Look for issues labeled [`good first issue`](https://github.
 
 ## Community
 
+- [ROADMAP](ROADMAP.md) — Where the project is going
 - [GitHub Discussions](https://github.com/PatrickAttankurugu/AfricaPEP/discussions) — Ask questions, share ideas
 - [GitHub Issues](https://github.com/PatrickAttankurugu/AfricaPEP/issues) — Report bugs, request features
 - [CHANGELOG](CHANGELOG.md) — See what's new

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,44 @@
+# AfricaPEP Roadmap
+
+This is the project's direction, kept honest and issue-linked. Items move as contributors pick them up; nothing here is a promise with a date. If you want to influence priorities, open a [Discussion](https://github.com/PatrickAttankurugu/AfricaPEP/discussions).
+
+## Now (v1.x)
+
+**Data quality and coverage**
+- Per-country data quality reports, validated by people who know each country ([#15](https://github.com/PatrickAttankurugu/AfricaPEP/issues/15), see [CONTRIBUTING-DATA.md](CONTRIBUTING-DATA.md))
+- Regional bodies: AU, ECOWAS, SADC, EAC officials ([#7](https://github.com/PatrickAttankurugu/AfricaPEP/issues/7))
+- Party affiliation extraction from Wikidata ([#5](https://github.com/PatrickAttankurugu/AfricaPEP/issues/5))
+- Better FATF tier classification for judiciary roles ([#3](https://github.com/PatrickAttankurugu/AfricaPEP/issues/3))
+
+**Name matching**
+- French name transliteration ([#2](https://github.com/PatrickAttankurugu/AfricaPEP/issues/2))
+- Arabic name transliteration for North Africa ([#8](https://github.com/PatrickAttankurugu/AfricaPEP/issues/8))
+- More African language support in matching ([#12](https://github.com/PatrickAttankurugu/AfricaPEP/issues/12))
+
+**Developer experience**
+- One-command Docker setup with bundled sample data ([#14](https://github.com/PatrickAttankurugu/AfricaPEP/issues/14))
+
+## Next
+
+**Beyond Wikidata**
+- First national data source scrapers (electoral commissions, gazettes, judiciary sites), built on the existing scraper framework. Each source gets its own issue with the `new-scraper` label.
+- Cross-source corroboration: records confirmed by two independent sources get a confidence marker.
+
+**Matching depth**
+- Phonetic candidate retrieval index, so purely phonetic matches are not gated by trigram overlap
+- Published evaluation metrics for name matching (precision/recall on the QID-grounded harness)
+
+**Operations**
+- Shared-store (Redis) rate limiting so limits hold exactly across workers and restarts
+- Public per-country coverage dashboard
+
+## Later
+
+- Dataset distribution: versioned exports published to Kaggle and Hugging Face Datasets
+- Interoperability with the OpenSanctions ecosystem (FollowTheMoney entity format export)
+- Sanctions and adverse-media adjacency: not in scope until PEP data quality is proven
+
+## Non-goals
+
+- Selling data or gating the API behind payment. AfricaPEP stays free and open source.
+- Storing any non-public personal data. Only public information about public officials.

--- a/africapep/api/main.py
+++ b/africapep/api/main.py
@@ -1,4 +1,5 @@
 """FastAPI application entry point with production hardening."""
+import secrets
 import time
 
 from fastapi import FastAPI, Request, status
@@ -38,7 +39,7 @@ app = FastAPI(
         "Built from scratch using web scrapers, NLP pipelines, and entity resolution — "
         "no third-party PEP data providers.\n\n"
         "### Key Features\n"
-        "- **Name Screening** — Fuzzy match names against 1,500+ PEP profiles\n"
+        "- **Name Screening** — Fuzzy match names against 34,000+ PEP profiles\n"
         "- **Batch Screening** — Screen up to 50 names in a single request\n"
         "- **Full-text Search** — Search by name, country, tier, and active status\n"
         "- **FATF-aligned Tiers** — Tier 1 (heads of state), Tier 2 (MPs/judges), Tier 3 (local officials)\n"
@@ -109,7 +110,7 @@ async def api_key_auth_middleware(request: Request, call_next):
         return await call_next(request)
 
     api_key = request.headers.get("X-API-Key")
-    if not api_key or api_key != settings.api_key:
+    if not api_key or not secrets.compare_digest(api_key, settings.api_key):
         return JSONResponse(
             status_code=status.HTTP_401_UNAUTHORIZED,
             content={

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./data/neo4j:/data
     environment:
-      NEO4J_AUTH: neo4j/${NEO4J_PASSWORD:-changeme}
+      NEO4J_AUTH: neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set for production}
       NEO4J_dbms_memory_heap_initial__size: 512m
       NEO4J_dbms_memory_heap_max__size: 1G
     healthcheck:
@@ -39,7 +39,7 @@ services:
       - ./data/postgres:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-africapep}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set for production}
       POSTGRES_DB: ${POSTGRES_DB:-africapep}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-africapep}"]

--- a/docs/API.md
+++ b/docs/API.md
@@ -339,6 +339,10 @@ Example response:
 
 Clients should implement retry or exponential backoff when receiving HTTP 429 responses.
 
+> **Note**
+>
+> Limits are tracked in memory per API worker process, so the effective ceiling can be somewhat higher than the stated values when the API runs with multiple workers, and counters reset when the service restarts. Treat the stated values as the guaranteed floor and do not design clients that depend on exceeding them.
+
 ---
 
 ## Error Responses

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ neo4j==5.19.0
 psycopg2-binary==2.9.9
 sqlalchemy==2.0.29
 beautifulsoup4==4.12.3
-requests==2.31.0
+requests==2.32.3
 httpx==0.27.0
 pdfplumber==0.11.0
 pymupdf==1.24.3


### PR DESCRIPTION
Three related cleanups ahead of v1.0.0:

**Claims**: the README badge said 32,476 profiles while main.py's OpenAPI description said 1,500+ and live /stats reports 34,582. Everything now says 34,000+. Test badge said 79; the suite has 170. Good-first-issues list pointed at completed work; now points at open issues. The data-source section now states plainly that Wikidata is the sole current source, with national sources framed as open contribution opportunities.

**Security**: requests bumped past CVE-2024-35195; prod compose now fails loudly if passwords are unset instead of silently starting with 'changeme'; API key comparison is constant-time; the per-worker rate-limit caveat is documented.

**Growth**: adds ROADMAP.md, CONTRIBUTING-DATA.md (non-code contribution guide for compliance professionals), and a Country Data Validation issue template.

Local verification: ruff clean, 149 tests passing.