### PR TITLE
feat: bundled offline sample dataset and make seed-sample

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup run seed test clean
+.PHONY: setup run seed seed-sample test clean
 
 setup:
 	cp -n .env.example .env || true
@@ -10,6 +10,9 @@ run:
 
 seed:
 	docker compose exec api python -m africapep.database.seed
+
+seed-sample:
+	docker compose exec api python -m africapep.database.seed_sample
 
 test:
 	docker compose exec api pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -111,11 +111,15 @@ git clone https://github.com/PatrickAttankurugu/AfricaPEP.git && cd AfricaPEP
 # 2. Setup the environment and start services
 make setup
 
-# 3. Seed with live PEP data from Wikidata (34,000+ profiles)
+# 3a. Quick start: seed with the bundled offline sample (2 countries, ~500 records, under a minute)
+make seed-sample
+
+# 3b. Or seed with live PEP data from Wikidata (all 54 countries, 34,000+ profiles, takes a while)
 make seed
 
 # 4. Success! API is live at http://localhost:8000
 curl http://localhost:8000/health
+curl -X POST http://localhost:8000/api/v1/screen -H "Content-Type: application/json" -d '{"name": "Adama Barrow"}'
 ```
 
 ## Local Development (Hot-Reload)

--- a/africapep/database/sample_data.json
+++ b/africapep/database/sample_data.json
@@ -1,0 +1,10740 @@
+{
+ "records": [
+  {
+   "full_name": "Abdul Aziz Abu Ghosh",
+   "title": "Ambassador of Palestine to Seychelles",
+   "institution": "Ambassador of Palestine to Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Abdul Aziz Abu Ghosh - Ambassador of Palestine to Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "http://www",
+    "end_date": "1990-01-01",
+    "is_current": false,
+    "date_of_birth": "1949-01-01",
+    "date_of_death": "2018-04-07",
+    "party": "",
+    "wikidata_qid": "Q101778213",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Ahmed Afif",
+   "title": "Vice President of Seychelles",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ahmed Afif - Vice President of Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-10-27",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1967-01-06",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q64010186",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Anne Lafortune",
+   "title": "ambassador of Seychelles",
+   "institution": "ambassador of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Anne Lafortune - ambassador of Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2021-06-17",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q123227433",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Antony Derjacques",
+   "title": "Minister for Transport",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Antony Derjacques - Minister for Transport",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-11-03",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q109703887",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "António Correia Sumbana",
+   "title": "Ambassador of Mozambique to the Seychelles",
+   "institution": "Ambassador of Mozambique to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "António Correia Sumbana - Ambassador of Mozambique to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1986-11-22",
+    "end_date": "http://www",
+    "is_current": false,
+    "date_of_birth": "1942-01-18",
+    "date_of_death": null,
+    "party": "FRELIMO",
+    "wikidata_qid": "Q111828605",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Arthur Grimble",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Arthur Grimble - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1936-01-01",
+    "end_date": "1942-01-05",
+    "is_current": false,
+    "date_of_birth": "1888-06-11",
+    "date_of_death": "1956-12-13",
+    "party": "",
+    "wikidata_qid": "Q651599",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Bernard Georges",
+   "title": "Leader of the Opposition",
+   "institution": "Leader of the Opposition",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bernard Georges - Leader of the Opposition",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1955-08-24",
+    "date_of_death": null,
+    "party": "Seychelles National Party",
+    "wikidata_qid": "Q4893161",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Billy Rangasamy",
+   "title": "Minister of Lands and Housing",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Billy Rangasamy - Minister of Lands and Housing",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-11-03",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q109703973",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Bruce Greatbatch",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bruce Greatbatch - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1969-01-01",
+    "end_date": "1973-01-01",
+    "is_current": false,
+    "date_of_birth": "1917-06-10",
+    "date_of_death": "1989-07-20",
+    "party": "",
+    "wikidata_qid": "Q4149749",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Caroline Abel",
+   "title": "Governor of the Central Bank of Seychelles",
+   "institution": "Governor of the Central Bank of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Caroline Abel - Governor of the Central Bank of Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2012-03-14",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1972-05-18",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q16161140",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Caron Röhsler",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Caron Röhsler - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2015-01-01",
+    "end_date": "2019-01-01",
+    "is_current": false,
+    "date_of_birth": "1972-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q57596580",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Charles O'Brien",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Charles O'Brien - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1912-01-01",
+    "end_date": "1918-01-01",
+    "is_current": false,
+    "date_of_birth": "1859-12-13",
+    "date_of_death": "1935-11-29",
+    "party": "",
+    "wikidata_qid": "Q5081298",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Colin Allan",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Colin Allan - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1973-01-01",
+    "end_date": "1975-10-01",
+    "is_current": false,
+    "date_of_birth": "1921-10-23",
+    "date_of_death": "1993-03-05",
+    "party": "",
+    "wikidata_qid": "Q5144843",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Colin Mays",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Colin Mays - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1983-01-01",
+    "end_date": "1986-01-01",
+    "is_current": false,
+    "date_of_birth": "1931-06-16",
+    "date_of_death": "2016-01-01",
+    "party": "",
+    "wikidata_qid": "Q57832553",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Danny Faure",
+   "title": "Vice President of Seychelles",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Danny Faure - Vice President of Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2010-06-30",
+    "end_date": "2016-10-16",
+    "is_current": false,
+    "date_of_birth": "1962-05-08",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q5220343",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Danny Faure",
+   "title": "President of Seychelles",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Danny Faure - President of Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2016-10-16",
+    "end_date": "2020-10-26",
+    "is_current": false,
+    "date_of_birth": "1962-05-08",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q5220343",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "David Dale Reimer",
+   "title": "United States Ambassador to Seychelles",
+   "institution": "United States Ambassador to Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "David Dale Reimer - United States Ambassador to Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2018-02-06",
+    "end_date": "2021-01-15",
+    "is_current": false,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q40608229",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "De Symons Montagu George Honey",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "De Symons Montagu George Honey - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1928-01-01",
+    "end_date": "1934-01-01",
+    "is_current": false,
+    "date_of_birth": "1872-11-01",
+    "date_of_death": "1945-01-01",
+    "party": "",
+    "wikidata_qid": "Q65598488",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Devika Vidot",
+   "title": "Minister for Investment, Entrepreneurship and Industry",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Devika Vidot - Minister for Investment, Entrepreneurship and Industry",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-11-03",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1988-11-18",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q101198923",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Dick Carlson",
+   "title": "United States Ambassador to Seychelles",
+   "institution": "United States Ambassador to Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Dick Carlson - United States Ambassador to Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1991-10-01",
+    "end_date": "1992-07-05",
+    "is_current": false,
+    "date_of_birth": "1941-02-02",
+    "date_of_death": "2025-03-24",
+    "party": "Republican Party",
+    "wikidata_qid": "Q18351656",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Didier Dogley",
+   "title": "Minister of Environment, Energy and Climate Change",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Didier Dogley - Minister of Environment, Energy and Climate Change",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2017-07-07",
+    "end_date": "2018-04-26",
+    "is_current": false,
+    "date_of_birth": "1964-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q21015395",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Didier Dogley",
+   "title": "Minister of Tourism, Civil Aviation, Ports and Marine",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Didier Dogley - Minister of Tourism, Civil Aviation, Ports and Marine",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2018-04-27",
+    "end_date": "2020-10-30",
+    "is_current": false,
+    "date_of_birth": "1964-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q21015395",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Dominique Mas",
+   "title": "ambassador of France to Seychelles",
+   "institution": "ambassador of France to Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Dominique Mas - ambassador of France to Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2019-01-01",
+    "end_date": "2022-01-01",
+    "is_current": false,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q100272017",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Eric Young",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Eric Young - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1980-01-01",
+    "end_date": "1983-01-01",
+    "is_current": false,
+    "date_of_birth": "1924-01-01",
+    "date_of_death": "2012-01-01",
+    "party": "",
+    "wikidata_qid": "Q56817037",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Ernest Bickham Sweet-Escott",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ernest Bickham Sweet-Escott - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1903-01-01",
+    "end_date": "1904-01-01",
+    "is_current": false,
+    "date_of_birth": "1857-08-20",
+    "date_of_death": "1941-04-09",
+    "party": "",
+    "wikidata_qid": "Q1356240",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Errol Fonseka",
+   "title": "Minister for Internal Affairs",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Errol Fonseka - Minister for Internal Affairs",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-11-03",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q109703822",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Eustace Fiennes",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Eustace Fiennes - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1918-01-01",
+    "end_date": "1922-01-01",
+    "is_current": false,
+    "date_of_birth": "1864-02-29",
+    "date_of_death": "1943-02-09",
+    "party": "Liberal Party",
+    "wikidata_qid": "Q7526658",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Fariz Mehdawi",
+   "title": "Ambassador of Palestine to Seychelles",
+   "institution": "Ambassador of Palestine to Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fariz Mehdawi - Ambassador of Palestine to Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1990-01-01",
+    "end_date": "2005-01-01",
+    "is_current": false,
+    "date_of_birth": "1951-10-19",
+    "date_of_death": "2026-04-08",
+    "party": "Fatah",
+    "wikidata_qid": "Q83375088",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Fergus Cochrane-Dyet",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fergus Cochrane-Dyet - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2007-01-01",
+    "end_date": "2009-01-01",
+    "is_current": false,
+    "date_of_birth": "1965-01-16",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q5444166",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Flavien Joubert",
+   "title": "Minister for Agriculture, Climate Change and Environment",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Flavien Joubert - Minister for Agriculture, Climate Change and Environment",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-11-03",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1972-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q109703838",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "France-Albert René",
+   "title": "Prime Minister of Seychelles",
+   "institution": "Prime Minister of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "France-Albert René - Prime Minister of Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1976-01-01",
+    "end_date": "1977-01-01",
+    "is_current": false,
+    "date_of_birth": "1935-11-16",
+    "date_of_death": "2019-02-27",
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q224986",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "France-Albert René",
+   "title": "President of Seychelles",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "France-Albert René - President of Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1977-06-05",
+    "end_date": "2004-04-16",
+    "is_current": false,
+    "date_of_birth": "1935-11-16",
+    "date_of_death": "2019-02-27",
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q224986",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Francis Doré",
+   "title": "ambassador of France to Seychelles",
+   "institution": "ambassador of France to Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Francis Doré - ambassador of France to Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1978-12-18",
+    "end_date": "1981-12-07",
+    "is_current": false,
+    "date_of_birth": "1933-05-04",
+    "date_of_death": "2019-09-05",
+    "party": "",
+    "wikidata_qid": "Q33288067",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Fraser Wilson",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fraser Wilson - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2002-01-01",
+    "end_date": "2004-01-01",
+    "is_current": false,
+    "date_of_birth": "1949-05-06",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q5493700",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Frederick Crawford",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Frederick Crawford - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1951-05-14",
+    "end_date": "1953-01-01",
+    "is_current": false,
+    "date_of_birth": "1906-03-09",
+    "date_of_death": "1978-05-27",
+    "party": "",
+    "wikidata_qid": "Q5497593",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Geneviève Iancu",
+   "title": "ambassador of France to Seychelles",
+   "institution": "ambassador of France to Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Geneviève Iancu - ambassador of France to Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2012-01-01",
+    "end_date": "2015-01-01",
+    "is_current": false,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q54913809",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Georges Vinson",
+   "title": "ambassador of France to Seychelles",
+   "institution": "ambassador of France to Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Georges Vinson - ambassador of France to Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1981-12-07",
+    "end_date": "1985-03-27",
+    "is_current": false,
+    "date_of_birth": "1930-02-11",
+    "date_of_death": "2013-02-19",
+    "party": "Socialist Party",
+    "wikidata_qid": "Q17351009",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Geva René",
+   "title": "First Lady of Seychelles",
+   "institution": "First Lady of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Geva René - First Lady of Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1977-06-05",
+    "end_date": "1992-01-01",
+    "is_current": false,
+    "date_of_birth": "1932-10-30",
+    "date_of_death": "2023-05-11",
+    "party": "",
+    "wikidata_qid": "Q135995820",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Ginko Sato",
+   "title": "ambassador to the Seychelles",
+   "institution": "ambassador to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ginko Sato - ambassador to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1934-07-06",
+    "date_of_death": "2023-12-09",
+    "party": "",
+    "wikidata_qid": "Q17158995",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Gordon James Lethem",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Gordon James Lethem - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1934-01-01",
+    "end_date": "1936-01-01",
+    "is_current": false,
+    "date_of_birth": "1886-01-01",
+    "date_of_death": "1962-08-14",
+    "party": "",
+    "wikidata_qid": "Q5585365",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Guy Hart",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Guy Hart - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1989-01-01",
+    "end_date": "1991-01-01",
+    "is_current": false,
+    "date_of_birth": "1931-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q57833908",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Hamdi Abu Ali",
+   "title": "Ambassador of Palestine to Seychelles",
+   "institution": "Ambassador of Palestine to Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Hamdi Abu Ali - Ambassador of Palestine to Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2019-09-22",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1972-09-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q104208260",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Hazem Shabat",
+   "title": "Ambassador of Palestine to Seychelles",
+   "institution": "Ambassador of Palestine to Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Hazem Shabat - Ambassador of Palestine to Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2016-05-17",
+    "end_date": "2018-01-01",
+    "is_current": false,
+    "date_of_birth": "1974-07-30",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q101830187",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Henry V. Jardine",
+   "title": "United States Ambassador to Seychelles",
+   "institution": "United States Ambassador to Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Henry V. Jardine - United States Ambassador to Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2023-03-21",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q112946866",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "James Mancham",
+   "title": "President of Seychelles",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "James Mancham - President of Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1976-06-29",
+    "end_date": "1977-06-05",
+    "is_current": false,
+    "date_of_birth": "1939-08-11",
+    "date_of_death": "2017-01-08",
+    "party": "Seychelles Democratic Party",
+    "wikidata_qid": "Q362948",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "James Michel",
+   "title": "Vice President of Seychelles",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "James Michel - Vice President of Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1996-08-01",
+    "end_date": "2004-04-16",
+    "is_current": false,
+    "date_of_birth": "1944-08-16",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q57476",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "James Michel",
+   "title": "President of Seychelles",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "James Michel - President of Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2004-04-16",
+    "end_date": "2016-10-16",
+    "is_current": false,
+    "date_of_birth": "1944-08-16",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q57476",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Jean-François Ferrari",
+   "title": "Minister for Fisheries",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Jean-François Ferrari - Minister for Fisheries",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-11-03",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1961-03-15",
+    "date_of_death": null,
+    "party": "Seychelles National Party",
+    "wikidata_qid": "Q6169248",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Jean-François Ferrari",
+   "title": "Designated Minister",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Jean-François Ferrari - Designated Minister",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-11-03",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1961-03-15",
+    "date_of_death": null,
+    "party": "Seychelles National Party",
+    "wikidata_qid": "Q6169248",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Jean-Paul Adam",
+   "title": "Minister for Foreign Affairs",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Jean-Paul Adam - Minister for Foreign Affairs",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2010-01-01",
+    "end_date": "2015-01-01",
+    "is_current": false,
+    "date_of_birth": "1977-06-12",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q17183684",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Jean-Paul Adam",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Jean-Paul Adam - Minister of Finance",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2015-02-01",
+    "end_date": "2016-10-01",
+    "is_current": false,
+    "date_of_birth": "1977-06-12",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q17183684",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Jeanne Siméon",
+   "title": "Minister of Education",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Jeanne Siméon - Minister of Education",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2018-04-27",
+    "end_date": "2020-11-03",
+    "is_current": false,
+    "date_of_birth": "1952-07-28",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q56249687",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Jeff Glekin",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Jeff Glekin - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2023-10-01",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q62104691",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Joevana Charles",
+   "title": "Member of the National Assembly of Seychelles",
+   "institution": "National Assembly",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Joevana Charles - Member of the National Assembly of Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1993-01-01",
+    "end_date": "2016-01-01",
+    "is_current": false,
+    "date_of_birth": "1955-07-01",
+    "date_of_death": "2021-01-17",
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q6214238",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "John Pugh",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "John Pugh - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1976-01-01",
+    "end_date": "1980-01-01",
+    "is_current": false,
+    "date_of_birth": "1920-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q57628885",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "John Sharland",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "John Sharland - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1992-01-01",
+    "end_date": "1995-01-01",
+    "is_current": false,
+    "date_of_birth": "1937-12-25",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q55855408",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "John Thorp",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "John Thorp - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1958-01-01",
+    "end_date": "1961-08-13",
+    "is_current": false,
+    "date_of_birth": "1912-06-13",
+    "date_of_death": "1961-08-13",
+    "party": "",
+    "wikidata_qid": "Q108649273",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "John Yapp",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "John Yapp - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1998-01-01",
+    "end_date": "2001-01-01",
+    "is_current": false,
+    "date_of_birth": "1951-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q56795469",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Joseph Aloysius Byrne",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Joseph Aloysius Byrne - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1922-01-01",
+    "end_date": "1927-01-01",
+    "is_current": false,
+    "date_of_birth": "1874-10-02",
+    "date_of_death": "1942-11-13",
+    "party": "",
+    "wikidata_qid": "Q6281002",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Joseph Belmont",
+   "title": "Vice President of Seychelles",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Joseph Belmont - Vice President of Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2004-04-16",
+    "end_date": "2010-06-30",
+    "is_current": false,
+    "date_of_birth": "1947-06-01",
+    "date_of_death": "2022-01-28",
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q12877508",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Julian Asquith, 2nd Earl of Oxford and Asquith",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Julian Asquith, 2nd Earl of Oxford and Asquith - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1962-01-01",
+    "end_date": "1967-01-01",
+    "is_current": false,
+    "date_of_birth": "1916-04-22",
+    "date_of_death": "2011-01-16",
+    "party": "",
+    "wikidata_qid": "Q335797",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Junor Young",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Junor Young - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1988-01-01",
+    "end_date": "1991-01-01",
+    "is_current": false,
+    "date_of_birth": "1934-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q57893500",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Justin Valentin",
+   "title": "Minister of Education",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Justin Valentin - Minister of Education",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-11-03",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1971-04-14",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q101007296",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Ken Okaniwa",
+   "title": "ambassador to the Seychelles",
+   "institution": "ambassador to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ken Okaniwa - ambassador to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1961-11-19",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q116936912",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Lindsay Skoll",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lindsay Skoll - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2012-01-01",
+    "end_date": "2015-01-01",
+    "is_current": false,
+    "date_of_birth": "1970-09-26",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q57593381",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Lionel Majesté-Larrouy",
+   "title": "ambassador of France to Seychelles",
+   "institution": "ambassador of France to Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lionel Majesté-Larrouy - ambassador of France to Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2015-01-01",
+    "end_date": "2019-01-01",
+    "is_current": false,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q50694218",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Macsuzy Mondon",
+   "title": "Minister of Health",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Macsuzy Mondon - Minister of Health",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2006-01-01",
+    "end_date": "2010-01-01",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q27914753",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Macsuzy Mondon",
+   "title": "Minister for Internal Affairs",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Macsuzy Mondon - Minister for Internal Affairs",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2016-10-01",
+    "end_date": "2020-10-01",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q27914753",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Macsuzy Mondon",
+   "title": "Minister of Education",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Macsuzy Mondon - Minister of Education",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2010-01-01",
+    "end_date": "2016-01-01",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q27914753",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Macsuzy Mondon",
+   "title": "Designated Minister",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Macsuzy Mondon - Designated Minister",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2016-10-28",
+    "end_date": "2020-11-03",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q27914753",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Malcolm Stevenson",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Malcolm Stevenson - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1927-05-01",
+    "end_date": "1927-11-01",
+    "is_current": false,
+    "date_of_birth": "1878-03-15",
+    "date_of_death": "1927-11-27",
+    "party": "",
+    "wikidata_qid": "Q6742650",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Marie-Celine Zialor",
+   "title": "Minister for Youth, Sports and Family",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Marie-Celine Zialor - Minister for Youth, Sports and Family",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-10-31",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q109703904",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Matthew Forbes",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Matthew Forbes - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2009-01-01",
+    "end_date": "2012-01-01",
+    "is_current": false,
+    "date_of_birth": "1966-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q56822766",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Maurice Loustau-Lalanne",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Maurice Loustau-Lalanne - Minister of Finance",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2018-04-27",
+    "end_date": "2020-10-29",
+    "is_current": false,
+    "date_of_birth": "1955-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q56380785",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Maurice Loustau-Lalanne",
+   "title": "Minister of Tourism, Civil Aviation, Ports and Marine",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Maurice Loustau-Lalanne - Minister of Tourism, Civil Aviation, Ports and Marine",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2016-12-30",
+    "end_date": "2018-04-26",
+    "is_current": false,
+    "date_of_birth": "1955-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q56380785",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Morihisa Aoki",
+   "title": "ambassador to the Seychelles",
+   "institution": "ambassador to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Morihisa Aoki - ambassador to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1938-11-23",
+    "date_of_death": "2024-11-09",
+    "party": "",
+    "wikidata_qid": "Q6144649",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Naadir Hassan",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Naadir Hassan - Minister of Finance",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-11-03",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1981-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q101005240",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Nasri Abu Jaish",
+   "title": "Ambassador of Palestine to Seychelles",
+   "institution": "Ambassador of Palestine to Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Nasri Abu Jaish - Ambassador of Palestine to Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2011-09-22",
+    "end_date": "2015-01-01",
+    "is_current": false,
+    "date_of_birth": "1967-04-20",
+    "date_of_death": null,
+    "party": "Palestinian People's Party",
+    "wikidata_qid": "Q82059994",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Olivia Berkeley-Christmann",
+   "title": "ambassador of France to Seychelles",
+   "institution": "ambassador of France to Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Olivia Berkeley-Christmann - ambassador of France to Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2022-09-02",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q73401908",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Patricia Francourt",
+   "title": "Minister for Employment and Social Affairs",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Patricia Francourt - Minister for Employment and Social Affairs",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-11-03",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1965-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q101198632",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Patrick Herminie",
+   "title": "President of Seychelles",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Patrick Herminie - President of Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2025-10-26",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1963-09-22",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q16190544",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Patrick Lynch",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Patrick Lynch - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2019-08-01",
+    "end_date": "2023-01-01",
+    "is_current": false,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q113303072",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Paulino José Macaringue",
+   "title": "Ambassador of Mozambique to the Seychelles",
+   "institution": "Ambassador of Mozambique to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Paulino José Macaringue - Ambassador of Mozambique to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2016-03-11",
+    "end_date": "http://www",
+    "is_current": false,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q111817475",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Peggy Vidot",
+   "title": "Minister of Health",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Peggy Vidot - Minister of Health",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-11-03",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q101038872",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Peter Smart",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Peter Smart - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1986-01-01",
+    "end_date": "1989-01-01",
+    "is_current": false,
+    "date_of_birth": "1932-02-19",
+    "date_of_death": "2002-01-01",
+    "party": "",
+    "wikidata_qid": "Q57593414",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Peter Thomson",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Peter Thomson - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1995-01-01",
+    "end_date": "1997-01-01",
+    "is_current": false,
+    "date_of_birth": "1938-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q57894118",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Philippe Delacroix",
+   "title": "ambassador of France to Seychelles",
+   "institution": "ambassador of France to Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Philippe Delacroix - ambassador of France to Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2009-01-01",
+    "end_date": "2012-01-01",
+    "is_current": false,
+    "date_of_birth": "1949-09-03",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q33105146",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Pierre Viaux",
+   "title": "ambassador of France to Seychelles",
+   "institution": "ambassador of France to Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Pierre Viaux - ambassador of France to Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1995-01-01",
+    "end_date": "1996-01-01",
+    "is_current": false,
+    "date_of_birth": "1945-02-23",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q1723389",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Rose-Marie Hoareau",
+   "title": "Minister for Local Government and Community Affairs",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Rose-Marie Hoareau - Minister for Local Government and Community Affairs",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-11-03",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q109703892",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Ryōichi Horie",
+   "title": "ambassador to the Seychelles",
+   "institution": "ambassador to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ryōichi Horie - ambassador to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1955-04-15",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q17208891",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Satoru Miyamura",
+   "title": "ambassador to the Seychelles",
+   "institution": "ambassador to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Satoru Miyamura - ambassador to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1946-11-26",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q7461475",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Selwyn Selwyn-Clarke",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Selwyn Selwyn-Clarke - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1947-07-01",
+    "end_date": "1951-05-14",
+    "is_current": false,
+    "date_of_birth": "1893-01-01",
+    "date_of_death": "1976-03-13",
+    "party": "",
+    "wikidata_qid": "Q457392",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Shigeo Iwatani",
+   "title": "ambassador to the Seychelles",
+   "institution": "ambassador to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Shigeo Iwatani - ambassador to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-09-08",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q7496360",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Sir Hugh Selby Norman-Walker",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sir Hugh Selby Norman-Walker - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1967-01-01",
+    "end_date": "1969-01-01",
+    "is_current": false,
+    "date_of_birth": "1916-12-17",
+    "date_of_death": "1985-08-28",
+    "party": "",
+    "wikidata_qid": "Q4327425",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Sylvestre Radegonde",
+   "title": "Minister for Foreign Affairs",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sylvestre Radegonde - Minister for Foreign Affairs",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-11-03",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1956-03-16",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q101110528",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Tatsushi Terada",
+   "title": "ambassador to the Seychelles",
+   "institution": "ambassador to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Tatsushi Terada - ambassador to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1953-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q11458034",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Toshihisa Takata",
+   "title": "ambassador to the Seychelles",
+   "institution": "ambassador to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Toshihisa Takata - ambassador to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1954-01-08",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q6142074",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Toshitsugu Uesawa",
+   "title": "ambassador to the Seychelles",
+   "institution": "ambassador to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Toshitsugu Uesawa - ambassador to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q118727129",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Vincent Meriton",
+   "title": "Vice President of Seychelles",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Vincent Meriton - Vice President of Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2016-10-28",
+    "end_date": "2020-10-27",
+    "is_current": false,
+    "date_of_birth": "1960-12-28",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q20089124",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Walter Edward Davidson",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Walter Edward Davidson - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1904-01-01",
+    "end_date": "1912-01-01",
+    "is_current": false,
+    "date_of_birth": "1859-04-20",
+    "date_of_death": "1923-09-15",
+    "party": "",
+    "wikidata_qid": "Q3565744",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Wavel Ramkalawan",
+   "title": "President of Seychelles",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Wavel Ramkalawan - President of Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-10-26",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1961-03-15",
+    "date_of_death": null,
+    "party": "Seychelles National Party",
+    "wikidata_qid": "Q1568174",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "William Addis",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "William Addis - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1953-05-31",
+    "end_date": "1958-01-01",
+    "is_current": false,
+    "date_of_birth": "1901-09-05",
+    "date_of_death": "1978-11-19",
+    "party": "",
+    "wikidata_qid": "Q108649202",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "William Marston Logan",
+   "title": "Governor of the Seychelles",
+   "institution": "Governor of the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "William Marston Logan - Governor of the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1942-01-05",
+    "end_date": "1947-07-01",
+    "is_current": false,
+    "date_of_birth": "1889-03-10",
+    "date_of_death": "1968-09-30",
+    "party": "",
+    "wikidata_qid": "Q108649219",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Diana Skingle",
+   "title": "High Commissioner of the United Kingdom to the Seychelles",
+   "institution": "High Commissioner of the United Kingdom to the Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Diana Skingle - High Commissioner of the United Kingdom to the Seychelles",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2004-01-01",
+    "end_date": "2007-01-01",
+    "is_current": false,
+    "date_of_birth": "1947-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q57593376",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Jeanne Siméon",
+   "title": "Minister of Family Affairs",
+   "institution": "Cabinet of Seychelles",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Jeanne Siméon - Minister of Family Affairs",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2017-03-15",
+    "end_date": "2018-04-26",
+    "is_current": false,
+    "date_of_birth": "1952-07-28",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q56249687",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Kusumasmoro",
+   "title": "ambassador of Indonesia to Kenya",
+   "institution": "ambassador of Indonesia to Kenya",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Kusumasmoro - ambassador of Indonesia to Kenya",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1924-10-14",
+    "date_of_death": "1998-01-01",
+    "party": "",
+    "wikidata_qid": "Q138781452",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Mohamad Hery Saripudin",
+   "title": "ambassador of Indonesia to Kenya",
+   "institution": "ambassador of Indonesia to Kenya",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Mohamad Hery Saripudin - ambassador of Indonesia to Kenya",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2020-09-14",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1901-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q124452132",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Alain St Ange",
+   "title": "ministre du Tourisme et de la Culture",
+   "institution": "ministre du Tourisme et de la Culture",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alain St Ange - ministre du Tourisme et de la Culture",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2012-03-14",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1954-10-24",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q20089126",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Anne Lafortune",
+   "title": "Seychellense Ambassador to China",
+   "institution": "Seychellense Ambassador to China",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Anne Lafortune - Seychellense Ambassador to China",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2023-04-01",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q123227433",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Anne Lafortune",
+   "title": "ambassador of Seychelles to Japan",
+   "institution": "ambassador of Seychelles to Japan",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Anne Lafortune - ambassador of Seychelles to Japan",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2023-01-01",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q123227433",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Anne Lafortune",
+   "title": "ambassador of Seychelles to South Korea",
+   "institution": "ambassador of Seychelles to South Korea",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Anne Lafortune - ambassador of Seychelles to South Korea",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "2023-01-01",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q123227433",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Ingrid Betancourt",
+   "title": "member of the Chamber of Representatives of Colombia",
+   "institution": "Chamber of Representatives of Colombia",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ingrid Betancourt - member of the Chamber of Representatives of Colombia",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1994-07-20",
+    "end_date": "1998-07-20",
+    "is_current": false,
+    "date_of_birth": "1961-12-25",
+    "date_of_death": null,
+    "party": "Colombian Liberal Party",
+    "wikidata_qid": "Q152472",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Ingrid Betancourt",
+   "title": "member of the Senate of Colombia",
+   "institution": "Senate of Colombia",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ingrid Betancourt - member of the Senate of Colombia",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1998-07-20",
+    "end_date": "2002-02-23",
+    "is_current": false,
+    "date_of_birth": "1961-12-25",
+    "date_of_death": null,
+    "party": "Colombian Liberal Party",
+    "wikidata_qid": "Q152472",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Jacques Hodoul",
+   "title": "education minister",
+   "institution": "education minister",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Jacques Hodoul - education minister",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1977-01-01",
+    "end_date": "1979-01-01",
+    "is_current": false,
+    "date_of_birth": "1943-09-01",
+    "date_of_death": "2021-05-03",
+    "party": "Seychelles Movement for Democracy",
+    "wikidata_qid": "Q6120652",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Jacques Hodoul",
+   "title": "foreign minister",
+   "institution": "foreign minister",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Jacques Hodoul - foreign minister",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1979-07-01",
+    "end_date": "1982-11-01",
+    "is_current": false,
+    "date_of_birth": "1943-09-01",
+    "date_of_death": "2021-05-03",
+    "party": "Seychelles Movement for Democracy",
+    "wikidata_qid": "Q6120652",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Joel Morgan",
+   "title": "foreign minister",
+   "institution": "foreign minister",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Joel Morgan - foreign minister",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1961-08-15",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q20089125",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Marie-Louise Potter",
+   "title": "ambassador to the United States of America",
+   "institution": "ambassador to the United States of America",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Marie-Louise Potter - ambassador to the United States of America",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1959-03-12",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q6762697",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Maxime Ferrari",
+   "title": "agriculture minister",
+   "institution": "agriculture minister",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Maxime Ferrari - agriculture minister",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1977-01-01",
+    "end_date": "1978-01-01",
+    "is_current": false,
+    "date_of_birth": "1930-01-27",
+    "date_of_death": "2021-06-29",
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q58812876",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Maxime Ferrari",
+   "title": "minister of planning",
+   "institution": "minister of planning",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Maxime Ferrari - minister of planning",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1978-01-01",
+    "end_date": "1982-01-01",
+    "is_current": false,
+    "date_of_birth": "1930-01-27",
+    "date_of_death": "2021-06-29",
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q58812876",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Maxime Ferrari",
+   "title": "minister of labor",
+   "institution": "ministry of labour",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Maxime Ferrari - minister of labor",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": "1975-01-01",
+    "end_date": "1977-01-01",
+    "is_current": false,
+    "date_of_birth": "1930-01-27",
+    "date_of_death": "2021-06-29",
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q58812876",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Pierre Laporte",
+   "title": "finance minister",
+   "institution": "finance ministry",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Pierre Laporte - finance minister",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q11995661",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Vincent Meriton",
+   "title": "deputy prime minister",
+   "institution": "deputy prime minister",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Vincent Meriton - deputy prime minister",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1960-12-28",
+    "date_of_death": null,
+    "party": "United Seychelles Party",
+    "wikidata_qid": "Q20089124",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Vivianne Fock Tave",
+   "title": "Seychellense Ambassador to China",
+   "institution": "Seychellense Ambassador to China",
+   "country_code": "SC",
+   "source_url": "https://www.wikidata.org/wiki/Q1042",
+   "source_type": "WIKIDATA",
+   "raw_text": "Vivianne Fock Tave - Seychellense Ambassador to China",
+   "scraped_at": "2026-07-13T14:28:30.634099+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q7937823",
+    "wikidata_country_qid": "Q1042"
+   }
+  },
+  {
+   "full_name": "Abdou F.M. Badjie",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Abdou F.M. Badjie - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q308336",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Abdou Kolley",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Abdou Kolley - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2015-03-16",
+    "end_date": "2017-01-19",
+    "is_current": false,
+    "date_of_birth": "1970-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q308351",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Abdoulaye Sanyang",
+   "title": "Minister of the Interior",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Abdoulaye Sanyang - Minister of the Interior",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2024-03-15",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q106465372",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Abdoulie Bojang",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Abdoulie Bojang - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1960-02-17",
+    "date_of_death": "2024-11-29",
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q308425",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Abdoulie Ceesay",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Abdoulie Ceesay - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56229135",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Abdoulie Jobe",
+   "title": "Minister of Energy and Petroleum",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Abdoulie Jobe - Minister of Energy and Petroleum",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2022-05-04",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q111986129",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Abdoulie Kanagi Jawla",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Abdoulie Kanagi Jawla - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1956-11-11",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q308435",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Abdoulie Suku Singhateh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Abdoulie Suku Singhateh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1970-02-10",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56461656",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Abou Karamba Kassamba",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Abou Karamba Kassamba - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": "2001-01-06",
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q323064",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Adama Barrow",
+   "title": "President of the Gambia",
+   "institution": "President of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Adama Barrow - President of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-01-19",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1965-02-15",
+    "date_of_death": null,
+    "party": "National Reconciliation Party",
+    "wikidata_qid": "Q27917049",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ahmad Malick Njie",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ahmad Malick Njie - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56261022",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ahmadou Lamin Samateh",
+   "title": "Minister of Health",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ahmadou Lamin Samateh - Minister of Health",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2019-03-27",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q109780542",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Akihiko Furuya",
+   "title": "ambassador to the Gambia",
+   "institution": "ambassador to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Akihiko Furuya - ambassador to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1946-10-05",
+    "date_of_death": "2022-04-23",
+    "party": "",
+    "wikidata_qid": "Q7401209",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Akira Nakajima",
+   "title": "ambassador to the Gambia",
+   "institution": "ambassador to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Akira Nakajima - ambassador to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1947-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q133894534",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alan Pover",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alan Pover - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1990-01-01",
+    "end_date": "1993-01-01",
+    "is_current": false,
+    "date_of_birth": "1932-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q57628988",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alec Ibbott",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alec Ibbott - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1988-01-01",
+    "end_date": "1990-01-01",
+    "is_current": false,
+    "date_of_birth": "1930-01-01",
+    "date_of_death": "2023-08-21",
+    "party": "",
+    "wikidata_qid": "Q56872477",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alexander Findlay",
+   "title": "Commandant of St Mary's Island",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alexander Findlay - Commandant of St Mary's Island",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1826-08-01",
+    "end_date": "1829-03-08",
+    "is_current": false,
+    "date_of_birth": "1800-01-01",
+    "date_of_death": "1851-05-10",
+    "party": "",
+    "wikidata_qid": "Q2642095",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alexander Findlay",
+   "title": "Lieutenant Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alexander Findlay - Lieutenant Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1830-01-28",
+    "end_date": "1830-04-17",
+    "is_current": false,
+    "date_of_birth": "1800-01-01",
+    "date_of_death": "1851-05-10",
+    "party": "",
+    "wikidata_qid": "Q2642095",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alexander Grant",
+   "title": "Commandant of St Mary's Island",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alexander Grant - Commandant of St Mary's Island",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1816-04-23",
+    "end_date": "1826-08-01",
+    "is_current": false,
+    "date_of_birth": "1800-01-01",
+    "date_of_death": "1827-09-29",
+    "party": "",
+    "wikidata_qid": "Q1355492",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alfusainey Ceesay",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alfusainey Ceesay - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56070681",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alhagie Darboe",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alhagie Darboe - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56166100",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alhagie Drammeh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alhagie Drammeh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56241378",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alhagie F. B. Sillah",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alhagie F. B. Sillah - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56070682",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alhagie H. Sowe",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alhagie H. Sowe - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Gambia Democratic Congress",
+    "wikidata_qid": "Q56064928",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alhagie Jawara",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alhagie Jawara - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56183128",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alhagie Mbow",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alhagie Mbow - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "National Reconciliation Party",
+    "wikidata_qid": "Q56159563",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alhagie S. Darboe",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alhagie S. Darboe - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56205565",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alhassana Bojang",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alhassana Bojang - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": "2016-11-23",
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56490363",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alieu Badara N’Jie",
+   "title": "Vice President of the Gambia",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alieu Badara N’Jie - Vice President of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1977-01-01",
+    "end_date": "1981-01-01",
+    "is_current": false,
+    "date_of_birth": "1904-10-17",
+    "date_of_death": "1982-04-21",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q1749174",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alieu N’gum",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alieu N’gum - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-08-12",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q2647041",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Almamy Touray",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Almamy Touray - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q1620155",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Amadou Camara",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Amadou Camara - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "National Reconciliation Party",
+    "wikidata_qid": "Q56070689",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Amadou O. Khan",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Amadou O. Khan - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56476260",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Amadou Sanneh",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Amadou Sanneh - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-02-01",
+    "end_date": "2019-03-15",
+    "is_current": false,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q28839644",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Amie Fabureh",
+   "title": "Minister of Agriculture",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Amie Fabureh - Minister of Agriculture",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2019-03-27",
+    "end_date": "2022-05-04",
+    "is_current": false,
+    "date_of_birth": "1970-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q62577118",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Andrew Barkworth Wright",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Andrew Barkworth Wright - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1947-03-29",
+    "end_date": "1949-12-01",
+    "is_current": false,
+    "date_of_birth": "1895-11-30",
+    "date_of_death": "1971-03-24",
+    "party": "",
+    "wikidata_qid": "Q503662",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "André Lewin",
+   "title": "ambassador of France to the Gambia",
+   "institution": "ambassador of France to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "André Lewin - ambassador of France to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1996-01-01",
+    "end_date": "1999-01-01",
+    "is_current": false,
+    "date_of_birth": "1934-01-26",
+    "date_of_death": "2012-10-18",
+    "party": "",
+    "wikidata_qid": "Q2848165",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ansumana Sanneh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ansumana Sanneh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q65184784",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Arthur Kennedy",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Arthur Kennedy - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1851-01-01",
+    "end_date": "1852-01-01",
+    "is_current": false,
+    "date_of_birth": "1809-04-05",
+    "date_of_death": "1883-06-03",
+    "party": "",
+    "wikidata_qid": "Q330140",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Arthur Richards, 1st Baron Milverton",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Arthur Richards, 1st Baron Milverton - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1934-04-12",
+    "end_date": "1936-10-22",
+    "is_current": false,
+    "date_of_birth": "1885-02-21",
+    "date_of_death": "1978-10-27",
+    "party": "",
+    "wikidata_qid": "Q711119",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Assan Musa Camara",
+   "title": "Vice President of the Gambia",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Assan Musa Camara - Vice President of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1972-01-01",
+    "end_date": "1977-01-01",
+    "is_current": false,
+    "date_of_birth": "1923-04-21",
+    "date_of_death": "2013-09-15",
+    "party": "United Party",
+    "wikidata_qid": "Q739208",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Assan Musa Camara",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Assan Musa Camara - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1977-01-01",
+    "end_date": "1978-01-01",
+    "is_current": false,
+    "date_of_birth": "1923-04-21",
+    "date_of_death": "2013-09-15",
+    "party": "United Party",
+    "wikidata_qid": "Q739208",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Assan Touray",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Assan Touray - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56241368",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ba Tambadou",
+   "title": "Minister of Justice",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ba Tambadou - Minister of Justice",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-02-07",
+    "end_date": "2020-06-30",
+    "is_current": false,
+    "date_of_birth": "1972-12-12",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q28732952",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Baba Galleh Jallow",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Baba Galleh Jallow - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56229145",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Baba Jobe",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Baba Jobe - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1959-01-01",
+    "date_of_death": "2011-10-28",
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q28736806",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Babanding K.K. Daffeh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Babanding K.K. Daffeh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1954-09-12",
+    "date_of_death": "2015-01-03",
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q18761874",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Babou Gaye Sonko",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Babou Gaye Sonko - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q65555743",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Baboucarr Bouy",
+   "title": "Minister of Public Service, Administrative Reforms, Policy Coordination and Delivery",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Baboucarr Bouy - Minister of Public Service, Administrative Reforms, Policy Coordination and Delivery",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2022-10-13",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q115007904",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Baboucarr Jatta",
+   "title": "Minister of the Interior",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Baboucarr Jatta - Minister of the Interior",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2005-03-29",
+    "end_date": "2006-11-22",
+    "is_current": false,
+    "date_of_birth": "1960-12-26",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q98594679",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Baboucarr Ousman Joof",
+   "title": "Minister of Trade, Industry, Regional Integration and Employment",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Baboucarr Ousman Joof - Minister of Trade, Industry, Regional Integration and Employment",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2022-10-13",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1963-10-10",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q112035139",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Baboucarr Ousman Joof",
+   "title": "Minister of Public Service, Administrative Reforms, Policy Coordination and Delivery",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Baboucarr Ousman Joof - Minister of Public Service, Administrative Reforms, Policy Coordination and Delivery",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2022-05-04",
+    "end_date": "2022-10-13",
+    "is_current": false,
+    "date_of_birth": "1963-10-10",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q112035139",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Baboucarr S. Fadera",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Baboucarr S. Fadera - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56488713",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Badara Joof",
+   "title": "Vice President of the Gambia",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Badara Joof - Vice President of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2022-05-04",
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": "2023-01-18",
+    "party": "independent politician",
+    "wikidata_qid": "Q28843913",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Badara Joof",
+   "title": "Minister of Higher Education, Research, Science and Technology",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Badara Joof - Minister of Higher Education, Research, Science and Technology",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-02-22",
+    "end_date": "2022-05-04",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": "2023-01-18",
+    "party": "independent politician",
+    "wikidata_qid": "Q28843913",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Bafaye Saidykhan",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bafaye Saidykhan - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1971-06-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56479388",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Bai Lamin Jobe",
+   "title": "Minister of Transport, Works and Infrastructure",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bai Lamin Jobe - Minister of Transport, Works and Infrastructure",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-02-22",
+    "end_date": "2022-05-04",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q28843665",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Bakary Bunja Dabo",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bakary Bunja Dabo - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1992-01-01",
+    "end_date": "1994-01-01",
+    "is_current": false,
+    "date_of_birth": "1946-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q98593862",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Bakary Bunja Darbo",
+   "title": "Vice President of the Gambia",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bakary Bunja Darbo - Vice President of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1982-05-01",
+    "end_date": "1992-01-01",
+    "is_current": false,
+    "date_of_birth": "1946-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q98635754",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Bakary Bunja Darboe",
+   "title": "Vice President of the Gambia",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bakary Bunja Darboe - Vice President of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1982-05-12",
+    "end_date": "1992-05-15",
+    "is_current": false,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q122146914",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Bakary Camara",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bakary Camara - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56191888",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Bakary Njie",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bakary Njie - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56235701",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Bakary Y. Badjie",
+   "title": "Minister of Youth and Sports",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bakary Y. Badjie - Minister of Youth and Sports",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2020-10-01",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q109780626",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Bala Garba Jahumpa",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bala Garba Jahumpa - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1994-01-01",
+    "end_date": "1995-03-20",
+    "is_current": false,
+    "date_of_birth": "1958-07-20",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q164492",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Bekai Camara",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bekai Camara - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1968-02-18",
+    "date_of_death": "2011-03-06",
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q814985",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Belinda Bidwell",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Belinda Bidwell - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1936-04-22",
+    "date_of_death": "2007-04-28",
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q815618",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Billay G. Tunkara",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Billay G. Tunkara - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-01-01",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q55426613",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Bintanding Jarju",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bintanding Jarju - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1957-04-10",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q864065",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Boniface Nyema Dalieh",
+   "title": "President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "institution": "President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Boniface Nyema Dalieh - President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1933-12-09",
+    "date_of_death": "2014-04-25",
+    "party": "",
+    "wikidata_qid": "Q892488",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Bora B. Mass",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bora B. Mass - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1972-04-12",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56479399",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Borrie L. S. B. Kolley",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Borrie L. S. B. Kolley - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56490357",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Buah Saidy",
+   "title": "Governor of the Central Bank of The Gambia",
+   "institution": "Governor of the Central Bank of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Buah Saidy - Governor of the Central Bank of The Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2020-10-01",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q99889099",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Buba A. Bojang",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Buba A. Bojang - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56285615",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Buba Baldeh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Buba Baldeh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1953-11-11",
+    "date_of_death": "2014-07-09",
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q17464742",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Buba Samura",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Buba Samura - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": "2001-01-06",
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q997370",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Cecil Hamilton Armitage",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Cecil Hamilton Armitage - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1921-01-03",
+    "end_date": "1927-03-10",
+    "is_current": false,
+    "date_of_birth": "1869-10-08",
+    "date_of_death": "1933-03-10",
+    "party": "",
+    "wikidata_qid": "Q1052302",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Cecilia Cole",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Cecilia Cole - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1921-01-01",
+    "date_of_death": "2006-07-02",
+    "party": "",
+    "wikidata_qid": "Q60554004",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Charles Fitzgerald",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Charles Fitzgerald - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1844-12-10",
+    "end_date": "1847-04-19",
+    "is_current": false,
+    "date_of_birth": "1792-01-01",
+    "date_of_death": "1887-12-29",
+    "party": "",
+    "wikidata_qid": "Q1064363",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Charles George Edward Patey",
+   "title": "Administrator of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Charles George Edward Patey - Administrator of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1866-02-19",
+    "end_date": "1869-01-01",
+    "is_current": false,
+    "date_of_birth": "1811-02-27",
+    "date_of_death": "1881-01-01",
+    "party": "",
+    "wikidata_qid": "Q1064518",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Cherno Omar Jallow",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Cherno Omar Jallow - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1959-08-07",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56476264",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Chiyuki Hiraoka",
+   "title": "ambassador to the Gambia",
+   "institution": "ambassador to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Chiyuki Hiraoka - ambassador to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1930-01-19",
+    "date_of_death": "1996-01-09",
+    "party": "",
+    "wikidata_qid": "Q7401008",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Churchill Falai Baldeh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Churchill Falai Baldeh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q108177382",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Claudiana Cole",
+   "title": "Minister of Basic and Secondary Education",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Claudiana Cole - Minister of Basic and Secondary Education",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-02-22",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "independent politician",
+    "wikidata_qid": "Q28836800",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Colin Crorkin",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Colin Crorkin - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2014-01-01",
+    "end_date": "2017-01-01",
+    "is_current": false,
+    "date_of_birth": "1957-01-31",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q27063362",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Cornelius Alfred Moloney",
+   "title": "Administrator of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Cornelius Alfred Moloney - Administrator of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1884-01-01",
+    "end_date": "1886-01-01",
+    "is_current": false,
+    "date_of_birth": "1848-01-01",
+    "date_of_death": "1913-08-13",
+    "party": "",
+    "wikidata_qid": "Q1133716",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Cornelius Hendricksen Kortright",
+   "title": "Administrator of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Cornelius Hendricksen Kortright - Administrator of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1873-01-01",
+    "end_date": "1875-02-12",
+    "is_current": false,
+    "date_of_birth": "1817-12-26",
+    "date_of_death": "1897-12-23",
+    "party": "",
+    "wikidata_qid": "Q1133823",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "David Belgrove",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "David Belgrove - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2020-01-01",
+    "end_date": "2023-01-01",
+    "is_current": false,
+    "date_of_birth": "1962-01-18",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q57166266",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "David Le Breton",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "David Le Breton - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1981-01-01",
+    "end_date": "1984-01-01",
+    "is_current": false,
+    "date_of_birth": "1931-01-01",
+    "date_of_death": "2023-01-01",
+    "party": "",
+    "wikidata_qid": "Q56808133",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "David Morley",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "David Morley - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2011-01-01",
+    "end_date": "2014-01-01",
+    "is_current": false,
+    "date_of_birth": "1954-10-23",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q5237733",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Dawda A. Jallow",
+   "title": "Minister of Justice",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Dawda A. Jallow - Minister of Justice",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2020-07-01",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q96678255",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Dawda J. K. Bah",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Dawda J. K. Bah - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56285011",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Dawda Kairaba Jawara",
+   "title": "President of the Gambia",
+   "institution": "President of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Dawda Kairaba Jawara - President of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1970-04-24",
+    "end_date": "1994-07-22",
+    "is_current": false,
+    "date_of_birth": "1924-05-16",
+    "date_of_death": "2019-08-27",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q312716",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Dawda Kairaba Jawara",
+   "title": "Prime Minister of The Gambia",
+   "institution": "Prime Minister of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Dawda Kairaba Jawara - Prime Minister of The Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1962-06-12",
+    "end_date": "1970-04-24",
+    "is_current": false,
+    "date_of_birth": "1924-05-16",
+    "date_of_death": "2019-08-27",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q312716",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Dawda Kawsu Jawara",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Dawda Kawsu Jawara - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56166103",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Demba B. T. Sambou",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Demba B. T. Sambou - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q56419039",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Demba Sabally",
+   "title": "Minister of Agriculture",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Demba Sabally - Minister of Agriculture",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2022-05-04",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q111971998",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Demba Sowe",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Demba Sowe - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": "2020-01-24",
+    "party": "Gambia Democratic Congress",
+    "wikidata_qid": "Q56167025",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Dembo Bojang",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Dembo Bojang - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "National Convention Party",
+    "wikidata_qid": "Q29535468",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Dembo K. M. Camara",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Dembo K. M. Camara - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56172760",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Dominic Mendy",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Dominic Mendy - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1959-10-13",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q1237618",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ebrima A. T. Jammeh",
+   "title": "Seyfo",
+   "institution": "Seyfo",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ebrima A. T. Jammeh - Seyfo",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2009-10-14",
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1985-01-01",
+    "date_of_death": "2023-07-23",
+    "party": "",
+    "wikidata_qid": "Q67816220",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ebrima Jammeh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ebrima Jammeh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1972-01-15",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56490362",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ebrima Janko Sanyang",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ebrima Janko Sanyang - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q1280080",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ebrima Mballow",
+   "title": "Minister of the Interior",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ebrima Mballow - Minister of the Interior",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2018-01-08",
+    "end_date": "2019-08-22",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": "2023-02-19",
+    "party": "",
+    "wikidata_qid": "Q28940801",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ebrima Sillah",
+   "title": "Minister of Information & Communication Infrastructure",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ebrima Sillah - Minister of Information & Communication Infrastructure",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2018-06-29",
+    "end_date": "2022-05-04",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q28837890",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ebrima Sillah",
+   "title": "Minister of Transport, Works and Infrastructure",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ebrima Sillah - Minister of Transport, Works and Infrastructure",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2022-05-04",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q28837890",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Edmund Norcott",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Edmund Norcott - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1843-10-30",
+    "end_date": "1844-03-15",
+    "is_current": false,
+    "date_of_birth": "1794-01-01",
+    "date_of_death": "1874-01-01",
+    "party": "",
+    "wikidata_qid": "Q1286699",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Edward Brandis Denham",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Edward Brandis Denham - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1928-11-29",
+    "end_date": "1930-09-11",
+    "is_current": false,
+    "date_of_birth": "1876-01-01",
+    "date_of_death": "1938-06-02",
+    "party": "",
+    "wikidata_qid": "Q1291745",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Edward John Cameron",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Edward John Cameron - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1914-04-11",
+    "end_date": "1920-07-01",
+    "is_current": false,
+    "date_of_birth": "1858-05-14",
+    "date_of_death": "1947-07-20",
+    "party": "",
+    "wikidata_qid": "Q33142206",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Edward Singhatey",
+   "title": "Vice President of the Gambia",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Edward Singhatey - Vice President of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1968-08-08",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q1293644",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Edward Windley",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Edward Windley - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1958-06-19",
+    "end_date": "1962-03-29",
+    "is_current": false,
+    "date_of_birth": "1909-03-10",
+    "date_of_death": "1972-01-05",
+    "party": "",
+    "wikidata_qid": "Q28935482",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Elhadji Abdou-Saleye",
+   "title": "ambassador of Niger to The Gambia",
+   "institution": "ambassador of Niger to The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Elhadji Abdou-Saleye - ambassador of Niger to The Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1979-01-15",
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1928-04-15",
+    "date_of_death": "2006-08-03",
+    "party": "",
+    "wikidata_qid": "Q3050866",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Elizabeth Renner",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Elizabeth Renner - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1946-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q1331301",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Eric Jenkinson",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Eric Jenkinson - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2002-01-01",
+    "end_date": "2006-01-01",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q57833726",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Eric Smith",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Eric Smith - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1979-01-01",
+    "end_date": "1981-01-01",
+    "is_current": false,
+    "date_of_birth": "1922-01-01",
+    "date_of_death": "2011-01-01",
+    "party": "",
+    "wikidata_qid": "Q57895239",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Fabakary Cham",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fabakary Cham - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": "2002-02-02",
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q1390063",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Fabakary Jatta",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fabakary Jatta - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1952-11-16",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q1390067",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Fafa Sanyang",
+   "title": "Minister of Energy and Petroleum",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fafa Sanyang - Minister of Energy and Petroleum",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-04-10",
+    "end_date": "2022-05-04",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "National People's Party",
+    "wikidata_qid": "Q29437065",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Fakebba N. L. Colley",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fakebba N. L. Colley - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": "2021-08-14",
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56191447",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Famara Jatta",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Famara Jatta - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1997-01-01",
+    "end_date": "2003-09-25",
+    "is_current": false,
+    "date_of_birth": "1958-07-16",
+    "date_of_death": "2012-03-17",
+    "party": "",
+    "wikidata_qid": "Q1395088",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Fatou K. Jawara",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fatou K. Jawara - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1983-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56235696",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Fatou Mbye",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fatou Mbye - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q60554798",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Fatou Sanyang Kinteh",
+   "title": "Minister of Gender, Children and Social Welfare",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fatou Sanyang Kinteh - Minister of Gender, Children and Social Welfare",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2019-03-01",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q61946976",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Fatoumata Tambajang",
+   "title": "Vice President of the Gambia",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fatoumata Tambajang - Vice President of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-11-09",
+    "end_date": "2018-06-29",
+    "is_current": false,
+    "date_of_birth": "1949-10-22",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q1398236",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Fatoumata Tambajang",
+   "title": "Minister of Women's Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fatoumata Tambajang - Minister of Women's Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-02-22",
+    "end_date": "2018-06-29",
+    "is_current": false,
+    "date_of_birth": "1949-10-22",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q1398236",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Fatoumatta Jahumpa-Ceesay",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fatoumatta Jahumpa-Ceesay - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1957-10-25",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56219634",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Fatoumatta Njai",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fatoumatta Njai - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q29573264",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Fernando Morán Calvo-Sotelo",
+   "title": "Ambassador of Spain to Gambia",
+   "institution": "Ambassador of Spain to Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fernando Morán Calvo-Sotelo - Ambassador of Spain to Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2004-04-02",
+    "end_date": "2008-07-19",
+    "is_current": false,
+    "date_of_birth": "1955-12-12",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q5859957",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Foday A. Jallow",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Foday A. Jallow - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1975-07-22",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56261024",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Foday Jibani Manka",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Foday Jibani Manka - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1942-11-20",
+    "date_of_death": "2014-12-30",
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q18710893",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Foday N. M. Drammeh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Foday N. M. Drammeh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56005593",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "George Abbas Kooli D'Arcy",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "George Abbas Kooli D'Arcy - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1859-09-01",
+    "end_date": "1866-02-19",
+    "is_current": false,
+    "date_of_birth": "1818-07-30",
+    "date_of_death": "1885-10-22",
+    "party": "",
+    "wikidata_qid": "Q5536026",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "George Chardin Denton",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "George Chardin Denton - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1901-01-11",
+    "end_date": "1911-12-21",
+    "is_current": false,
+    "date_of_birth": "1851-06-22",
+    "date_of_death": "1928-01-09",
+    "party": "",
+    "wikidata_qid": "Q19059378",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "George Chardin Denton",
+   "title": "Administrator of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "George Chardin Denton - Administrator of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1900-01-01",
+    "end_date": "1901-01-11",
+    "is_current": false,
+    "date_of_birth": "1851-06-22",
+    "date_of_death": "1928-01-09",
+    "party": "",
+    "wikidata_qid": "Q19059378",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "George E. Crombie",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "George E. Crombie - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1965-01-01",
+    "end_date": "1968-01-01",
+    "is_current": false,
+    "date_of_birth": "1908-01-01",
+    "date_of_death": "1972-01-01",
+    "party": "",
+    "wikidata_qid": "Q57597060",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Gilbert Thomas Carter",
+   "title": "Administrator of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Gilbert Thomas Carter - Administrator of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1888-12-01",
+    "end_date": "1891-01-01",
+    "is_current": false,
+    "date_of_birth": "1848-01-14",
+    "date_of_death": "1927-01-18",
+    "party": "",
+    "wikidata_qid": "Q1524074",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Granville Ramage",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Granville Ramage - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1968-01-01",
+    "end_date": "1971-01-01",
+    "is_current": false,
+    "date_of_birth": "1919-01-01",
+    "date_of_death": "2011-01-01",
+    "party": "",
+    "wikidata_qid": "Q57628905",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Habib Saihou Drammeh",
+   "title": "Minister of the Interior",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Habib Saihou Drammeh - Minister of the Interior",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-12-04",
+    "end_date": "2018-01-08",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q54637664",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Habiboulie K. Jawo",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Habiboulie K. Jawo - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56243284",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Habsana Jallow",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Habsana Jallow - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "People's Democratic Organisation for Independence and Socialism",
+    "wikidata_qid": "Q56421695",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Halifa Sallah",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Halifa Sallah - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1953-01-01",
+    "date_of_death": null,
+    "party": "People's Democratic Organisation for Independence and Socialism",
+    "wikidata_qid": "Q3125967",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Hamat Bah",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Hamat Bah - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1960-05-01",
+    "date_of_death": null,
+    "party": "National Reconciliation Party",
+    "wikidata_qid": "Q1572664",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Hans-Günter Sulimma",
+   "title": "ambassador of Germany to the Gambia",
+   "institution": "ambassador of Germany to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Hans-Günter Sulimma - ambassador of Germany to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1975-01-01",
+    "end_date": "1978-01-01",
+    "is_current": false,
+    "date_of_birth": "1933-10-22",
+    "date_of_death": "2020-12-15",
+    "party": "",
+    "wikidata_qid": "Q24567667",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Harriet King",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Harriet King - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2023-09-01",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q138661811",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Hassan Bubacar Jallow",
+   "title": "Solicitor General of the Gambia",
+   "institution": "Solicitor General of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Hassan Bubacar Jallow - Solicitor General of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1982-01-01",
+    "end_date": "1984-01-01",
+    "is_current": false,
+    "date_of_birth": "1951-08-14",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q176771",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Hassan Bubacar Jallow",
+   "title": "Minister of Justice",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Hassan Bubacar Jallow - Minister of Justice",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1984-07-01",
+    "end_date": "1994-07-01",
+    "is_current": false,
+    "date_of_birth": "1951-08-14",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q176771",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Henry Galway",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Henry Galway - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1911-12-21",
+    "end_date": "1914-04-11",
+    "is_current": false,
+    "date_of_birth": "1859-09-25",
+    "date_of_death": "1949-06-17",
+    "party": "",
+    "wikidata_qid": "Q204631",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Henry Vere Huntley",
+   "title": "Lieutenant Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Henry Vere Huntley - Lieutenant Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1840-04-09",
+    "end_date": "1841-05-31",
+    "is_current": false,
+    "date_of_birth": "1795-01-01",
+    "date_of_death": "1864-05-07",
+    "party": "",
+    "wikidata_qid": "Q1607345",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Herbert Richmond Palmer",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Herbert Richmond Palmer - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1930-09-11",
+    "end_date": "1934-04-12",
+    "is_current": false,
+    "date_of_birth": "1877-04-18",
+    "date_of_death": "1958-05-22",
+    "party": "",
+    "wikidata_qid": "Q5735394",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Hilary Rudolph Robert Blood",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Hilary Rudolph Robert Blood - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1942-03-23",
+    "end_date": "1947-03-29",
+    "is_current": false,
+    "date_of_birth": "1893-05-28",
+    "date_of_death": "1967-06-20",
+    "party": "",
+    "wikidata_qid": "Q1230761",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Hiroshi Fukada",
+   "title": "ambassador to the Gambia",
+   "institution": "ambassador to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Hiroshi Fukada - ambassador to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1952-02-27",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q7401058",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ibrahima Garba Jahumpa",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ibrahima Garba Jahumpa - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1972-01-01",
+    "end_date": "1977-01-01",
+    "is_current": false,
+    "date_of_birth": "1912-11-22",
+    "date_of_death": "1994-01-01",
+    "party": "",
+    "wikidata_qid": "Q18529119",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Isatou N’jie-Saidy",
+   "title": "Vice President of the Gambia",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Isatou N’jie-Saidy - Vice President of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1997-03-20",
+    "end_date": "2017-01-18",
+    "is_current": false,
+    "date_of_birth": "1952-03-05",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q467531",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Isatou N’jie-Saidy",
+   "title": "Minister of Women's Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Isatou N’jie-Saidy - Minister of Women's Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1996-07-01",
+    "end_date": "2017-01-18",
+    "is_current": false,
+    "date_of_birth": "1952-03-05",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q467531",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Isatou Touray",
+   "title": "Vice President of the Gambia",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Isatou Touray - Vice President of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2019-03-15",
+    "end_date": "2022-05-03",
+    "is_current": false,
+    "date_of_birth": "1955-03-17",
+    "date_of_death": null,
+    "party": "independent politician",
+    "wikidata_qid": "Q27541581",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Isatou Touray",
+   "title": "Minister of Health",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Isatou Touray - Minister of Health",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2018-07-09",
+    "end_date": "2019-03-27",
+    "is_current": false,
+    "date_of_birth": "1955-03-17",
+    "date_of_death": null,
+    "party": "independent politician",
+    "wikidata_qid": "Q27541581",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Isatou Touray",
+   "title": "Minister of Trade, Industry, Regional Integration and Employment",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Isatou Touray - Minister of Trade, Industry, Regional Integration and Employment",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-02-01",
+    "end_date": "2018-07-09",
+    "is_current": false,
+    "date_of_birth": "1955-03-17",
+    "date_of_death": null,
+    "party": "independent politician",
+    "wikidata_qid": "Q27541581",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "James F. P. Gomez",
+   "title": "Minister of Fisheries and Water Resources",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "James F. P. Gomez - Minister of Fisheries and Water Resources",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-02-01",
+    "end_date": "2022-05-04",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q28842314",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "James Parker",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "James Parker - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1972-01-01",
+    "end_date": "1975-01-01",
+    "is_current": false,
+    "date_of_birth": "1919-12-20",
+    "date_of_death": "2009-11-17",
+    "party": "",
+    "wikidata_qid": "Q4476142",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "James Shaw Hay",
+   "title": "Administrator of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "James Shaw Hay - Administrator of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1886-01-01",
+    "end_date": "1888-12-01",
+    "is_current": false,
+    "date_of_birth": "1839-10-25",
+    "date_of_death": "1924-06-20",
+    "party": "",
+    "wikidata_qid": "Q1681090",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Jean-Christophe Rufin",
+   "title": "ambassador of France to the Gambia",
+   "institution": "ambassador of France to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Jean-Christophe Rufin - ambassador of France to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2007-01-01",
+    "end_date": "2010-01-01",
+    "is_current": false,
+    "date_of_birth": "1952-06-28",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q713222",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Jeremiah Thomas Fitzgerald Callaghan",
+   "title": "Administrator of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Jeremiah Thomas Fitzgerald Callaghan - Administrator of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1871-01-01",
+    "end_date": "1873-01-01",
+    "is_current": false,
+    "date_of_birth": "1827-12-27",
+    "date_of_death": "1881-07-09",
+    "party": "",
+    "wikidata_qid": "Q26243105",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Jesús Ezquerra Calvo",
+   "title": "Ambassador of Spain to Gambia",
+   "institution": "Ambassador of Spain to Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Jesús Ezquerra Calvo - Ambassador of Spain to Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1981-01-01",
+    "end_date": "1983-01-01",
+    "is_current": false,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q110276141",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "John C. O'Riordan",
+   "title": "President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "institution": "President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "John C. O'Riordan - President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1924-01-06",
+    "date_of_death": "2016-11-22",
+    "party": "",
+    "wikidata_qid": "Q788899",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "John Donald Garner",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "John Donald Garner - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1984-01-01",
+    "end_date": "1988-01-01",
+    "is_current": false,
+    "date_of_birth": "1931-04-01",
+    "date_of_death": "2019-01-01",
+    "party": "",
+    "wikidata_qid": "Q6229711",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "John Middleton",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "John Middleton - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1927-03-10",
+    "end_date": "1928-11-29",
+    "is_current": false,
+    "date_of_birth": "1870-01-01",
+    "date_of_death": "1954-01-01",
+    "party": "",
+    "wikidata_qid": "Q971540",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "John Perrott",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "John Perrott - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2000-01-01",
+    "end_date": "2002-01-01",
+    "is_current": false,
+    "date_of_birth": "1943-07-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q57628927",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "John Warburton Paul",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "John Warburton Paul - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1962-03-29",
+    "end_date": "1965-02-18",
+    "is_current": false,
+    "date_of_birth": "1916-03-29",
+    "date_of_death": "2004-03-31",
+    "party": "",
+    "wikidata_qid": "Q713388",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "John Wilde",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "John Wilde - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1995-01-01",
+    "end_date": "1998-01-01",
+    "is_current": false,
+    "date_of_birth": "1941-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q56811084",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Joseph Ganda",
+   "title": "President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "institution": "President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Joseph Ganda - President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1932-03-22",
+    "date_of_death": "2023-08-09",
+    "party": "",
+    "wikidata_qid": "Q1424695",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "José María Alvarez de Sotomayor y Castro",
+   "title": "Ambassador of Spain to Gambia",
+   "institution": "Ambassador of Spain to Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "José María Alvarez de Sotomayor y Castro - Ambassador of Spain to Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1978-01-01",
+    "end_date": "1981-01-01",
+    "is_current": false,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q113620606",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Kaddy Camara",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Kaddy Camara - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56233158",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Kajali Fofana",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Kajali Fofana - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56192034",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Kalifa Kambi",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Kalifa Kambi - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1955-05-01",
+    "date_of_death": "2011-12-20",
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q1525179",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Kanimang Sanneh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Kanimang Sanneh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q1615901",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Karafa Badjie",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Karafa Badjie - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56314167",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Kasum Jallow",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Kasum Jallow - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56243156",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Kebba Jallow",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Kebba Jallow - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Gambia Democratic Congress",
+    "wikidata_qid": "Q56192029",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Kebba K. Barrow",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Kebba K. Barrow - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56216499",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Kebba S. Touray",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Kebba S. Touray - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2013-07-10",
+    "end_date": "2015-03-16",
+    "is_current": false,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q98593632",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Kumba Jaiteh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Kumba Jaiteh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56289458",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Kunda Kamara",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Kunda Kamara - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1947-08-19",
+    "date_of_death": "2001-01-06",
+    "party": "",
+    "wikidata_qid": "Q60553418",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lamin B. Dibba",
+   "title": "Minister of Environment, Climate Change and Natural Resources",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lamin B. Dibba - Minister of Environment, Climate Change and Natural Resources",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-02-01",
+    "end_date": "2022-05-04",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "National Convention Party",
+    "wikidata_qid": "Q28843551",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lamin Bora M’Boge",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lamin Bora M’Boge - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1977-01-01",
+    "end_date": "1977-01-01",
+    "is_current": false,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q98594466",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lamin F. M. Conta",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lamin F. M. Conta - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56229136",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lamin Hydara",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lamin Hydara - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56479395",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lamin J. Sanneh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lamin J. Sanneh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56205582",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lamin Jadama",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lamin Jadama - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1963-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56271401",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lamin Kaba Bajo",
+   "title": "Minister of the Interior",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lamin Kaba Bajo - Minister of the Interior",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1995-01-27",
+    "end_date": "1997-03-08",
+    "is_current": false,
+    "date_of_birth": "1964-11-10",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q174328",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lamin Kebba Jammeh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lamin Kebba Jammeh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1963-02-18",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56452334",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lamin Kiti Jabang",
+   "title": "Minister of the Interior",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lamin Kiti Jabang - Minister of the Interior",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1987-01-01",
+    "end_date": "1994-01-01",
+    "is_current": false,
+    "date_of_birth": "1942-12-12",
+    "date_of_death": null,
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q1801566",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lamin M. M. Bojang",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lamin M. M. Bojang - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1959-01-01",
+    "date_of_death": "2011-04-09",
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q991990",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lamin N. Dibba",
+   "title": "Minister of Agriculture",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lamin N. Dibba - Minister of Agriculture",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2018-07-09",
+    "end_date": "2019-03-15",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": "2020-11-14",
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q28842315",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lamin Queen Jammeh",
+   "title": "Minister of Information & Communication Infrastructure",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lamin Queen Jammeh - Minister of Information & Communication Infrastructure",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2022-05-04",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1963-05-21",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q112036396",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lamin Saine",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lamin Saine - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1947-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q28924985",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Louise N’Jie",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Louise N’Jie - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1922-01-23",
+    "date_of_death": "2014-05-02",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q1872177",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Luke O'Connor",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Luke O'Connor - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1852-01-01",
+    "end_date": "1859-01-01",
+    "is_current": false,
+    "date_of_birth": "1806-01-01",
+    "date_of_death": "1873-01-01",
+    "party": "",
+    "wikidata_qid": "Q18528769",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Madi Ceesay",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Madi Ceesay - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1957-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q1883334",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Mahtarr M. Jeng",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Mahtarr M. Jeng - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56191444",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Mai Fatty",
+   "title": "Minister of the Interior",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Mai Fatty - Minister of the Interior",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-02-01",
+    "end_date": "2017-11-10",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Gambia Moral Congress",
+    "wikidata_qid": "Q28925135",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Mam Mbye Secka",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Mam Mbye Secka - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": "2006-12-08",
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q28873762",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Mama Fatima Singhateh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Mama Fatima Singhateh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q23772063",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Mama Fatima Singhateh",
+   "title": "Minister of Justice",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Mama Fatima Singhateh - Minister of Justice",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2013-08-27",
+    "end_date": "2014-08-27",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q23772063",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Mambury Njie",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Mambury Njie - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2018-06-29",
+    "end_date": "2022-05-04",
+    "is_current": false,
+    "date_of_birth": "1962-06-27",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q22006596",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Margaret Keita",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Margaret Keita - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1960-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q1894851",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Mariam Jack-Denton",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Mariam Jack-Denton - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-04-01",
+    "end_date": "2022-04-01",
+    "is_current": false,
+    "date_of_birth": "1955-12-29",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q29580200",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Martin Rogers",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Martin Rogers - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1975-01-01",
+    "end_date": "1979-01-01",
+    "is_current": false,
+    "date_of_birth": "1925-01-01",
+    "date_of_death": "2012-01-01",
+    "party": "",
+    "wikidata_qid": "Q57628577",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "María Dolores Ríos Peset",
+   "title": "Ambassador of Spain to Gambia",
+   "institution": "Ambassador of Spain to Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "María Dolores Ríos Peset - Ambassador of Spain to Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2024-05-28",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1966-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q120973956",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Matarr Kujabi",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Matarr Kujabi - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1969-05-11",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56490361",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Michael Hardie",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Michael Hardie - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1993-01-01",
+    "end_date": "1995-01-01",
+    "is_current": false,
+    "date_of_birth": "1938-01-01",
+    "date_of_death": "2008-01-01",
+    "party": "",
+    "wikidata_qid": "Q57834117",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Michael J. Cleary",
+   "title": "President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "institution": "President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Michael J. Cleary - President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1925-09-01",
+    "date_of_death": "2020-09-03",
+    "party": "",
+    "wikidata_qid": "Q974137",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Michael Joseph Moloney",
+   "title": "President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "institution": "President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Michael Joseph Moloney - President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1912-05-12",
+    "date_of_death": "1991-12-31",
+    "party": "",
+    "wikidata_qid": "Q28115470",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Michael Kpakala Francis",
+   "title": "President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "institution": "President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Michael Kpakala Francis - President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1936-02-12",
+    "date_of_death": "2013-05-19",
+    "party": "",
+    "wikidata_qid": "Q5412348",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Mitsuhei Murata",
+   "title": "ambassador to the Gambia",
+   "institution": "ambassador to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Mitsuhei Murata - ambassador to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1938-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q21019702",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Modou Bamba",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Modou Bamba - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "National Reconciliation Party",
+    "wikidata_qid": "Q28925177",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Momodou Alieu Bah",
+   "title": "Minister of the Interior",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Momodou Alieu Bah - Minister of the Interior",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2016-09-19",
+    "end_date": "2017-01-18",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q28861463",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Momodou Bojang",
+   "title": "Minister of the Interior",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Momodou Bojang - Minister of the Interior",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1997-03-08",
+    "end_date": "1999-01-27",
+    "is_current": false,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q98594727",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Momodou C. Cham",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Momodou C. Cham - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1978-01-01",
+    "end_date": "1981-01-01",
+    "is_current": false,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q98594378",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Momodou Camara",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Momodou Camara - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56229139",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Momodou Ceesay",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Momodou Ceesay - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56172860",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Momodou L. K. Sanneh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Momodou L. K. Sanneh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1942-01-01",
+    "date_of_death": null,
+    "party": "National Convention Party",
+    "wikidata_qid": "Q28839669",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Momodou S. Foon",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Momodou S. Foon - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q1943882",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Muhammed Magassy",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Muhammed Magassy - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1977-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q29577935",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Muhammed Mahanera",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Muhammed Mahanera - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q55986149",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Muhammed Ndow",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Muhammed Ndow - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q56241371",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Musa Amul Nyassi",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Musa Amul Nyassi - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56233171",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Musa Baldeh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Musa Baldeh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q65384041",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Musa Drammeh",
+   "title": "Minister of Fisheries and Water Resources",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Musa Drammeh - Minister of Fisheries and Water Resources",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2022-05-04",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q55286729",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Musa Drammeh",
+   "title": "Minister of Lands, Regional Government and Religious Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Musa Drammeh - Minister of Lands, Regional Government and Religious Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2018-06-29",
+    "end_date": "2022-05-04",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q55286729",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Musa Gallel J. Njadoe",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Musa Gallel J. Njadoe - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "National Reconciliation Party",
+    "wikidata_qid": "Q56314165",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Musa Gibril Bala Gaye",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Musa Gibril Bala Gaye - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2003-09-15",
+    "end_date": "2009-06-01",
+    "is_current": false,
+    "date_of_birth": "1946-08-13",
+    "date_of_death": "2026-01-08",
+    "party": "",
+    "wikidata_qid": "Q1953955",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Mustapha B. Wadda",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Mustapha B. Wadda - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1930-10-01",
+    "date_of_death": "2010-01-31",
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q1955595",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ndey Yassin Secka",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ndey Yassin Secka - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "People's Democratic Organisation for Independence and Socialism",
+    "wikidata_qid": "Q55846074",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Netty Baldeh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Netty Baldeh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56410847",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Njai Darboe",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Njai Darboe - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56479398",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Nyimasata Sanneh-Bojang",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Nyimasata Sanneh-Bojang - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1941-01-01",
+    "date_of_death": "2015-07-15",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q2006110",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Oley Sey",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Oley Sey - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q63807981",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Olga Cabarga Gómez",
+   "title": "Ambassador of Spain to Gambia",
+   "institution": "Ambassador of Spain to Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Olga Cabarga Gómez - Ambassador of Spain to Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2020-12-15",
+    "end_date": "2024-03-19",
+    "is_current": false,
+    "date_of_birth": "1964-12-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q6049793",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Omar A. Jallow",
+   "title": "Minister of Agriculture",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Omar A. Jallow - Minister of Agriculture",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-02-01",
+    "end_date": "2018-07-09",
+    "is_current": false,
+    "date_of_birth": "1946-10-26",
+    "date_of_death": "2023-05-14",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q29537096",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Omar Ceesay",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Omar Ceesay - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1992-09-01",
+    "date_of_death": null,
+    "party": "Gambia Democratic Congress",
+    "wikidata_qid": "Q56166580",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Omar Darboe",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Omar Darboe - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56190902",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Omar Tobb",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Omar Tobb - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q56333767",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Osamu Izawa",
+   "title": "ambassador to the Gambia",
+   "institution": "ambassador to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Osamu Izawa - ambassador to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1963-08-16",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q113566454",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ousainou Darboe",
+   "title": "Vice President of the Gambia",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ousainou Darboe - Vice President of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2018-06-29",
+    "end_date": "2019-03-15",
+    "is_current": false,
+    "date_of_birth": "1948-08-08",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q710820",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ousainou Darboe",
+   "title": "Minister of Women's Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ousainou Darboe - Minister of Women's Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2018-06-29",
+    "end_date": "2019-03-15",
+    "is_current": false,
+    "date_of_birth": "1948-08-08",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q710820",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ousman Badjie",
+   "title": "Minister of the Interior",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ousman Badjie - Minister of the Interior",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1999-01-27",
+    "end_date": "2003-09-29",
+    "is_current": false,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q2041805",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ousman Bah",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ousman Bah - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1969-09-20",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56450660",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ousman Koro Ceesay",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ousman Koro Ceesay - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1995-03-20",
+    "end_date": "1995-06-22",
+    "is_current": false,
+    "date_of_birth": "1962-01-01",
+    "date_of_death": "1995-06-22",
+    "party": "",
+    "wikidata_qid": "Q2041817",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ousman Njie",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ousman Njie - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56419038",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ousman Sillah",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ousman Sillah - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "People's Democratic Organisation for Independence and Socialism",
+    "wikidata_qid": "Q56241370",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ousman Sonko",
+   "title": "Minister of the Interior",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ousman Sonko - Minister of the Interior",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2006-11-22",
+    "end_date": "2012-04-16",
+    "is_current": false,
+    "date_of_birth": "1969-01-09",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q24018735",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ousman Touray",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ousman Touray - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "National Reconciliation Party",
+    "wikidata_qid": "Q56172752",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Pa Malick Ceesay",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Pa Malick Ceesay - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "National Reconciliation Party",
+    "wikidata_qid": "Q56447780",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Patricia Alsup",
+   "title": "United States Ambassador to the Gambia",
+   "institution": "United States Ambassador to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Patricia Alsup - United States Ambassador to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2016-01-13",
+    "end_date": "2018-09-22",
+    "is_current": false,
+    "date_of_birth": "1961-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q23888415",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Patrick Daniel Koroma",
+   "title": "President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "institution": "President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Patrick Daniel Koroma - President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1950-05-04",
+    "date_of_death": "2018-12-14",
+    "party": "",
+    "wikidata_qid": "Q2057518",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Paul L. Mendy",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Paul L. Mendy - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1958-09-24",
+    "date_of_death": "2013-06-03",
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q19298298",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Percy Wyn-Harris",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Percy Wyn-Harris - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1949-12-01",
+    "end_date": "1958-06-19",
+    "is_current": false,
+    "date_of_birth": "1903-08-24",
+    "date_of_death": "1979-02-25",
+    "party": "",
+    "wikidata_qid": "Q1752285",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Philp Sinkinson",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Philp Sinkinson - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2006-01-01",
+    "end_date": "2011-01-01",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q57593367",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Pierre Gomez",
+   "title": "Minister of Higher Education, Research, Science and Technology",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Pierre Gomez - Minister of Higher Education, Research, Science and Technology",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2022-05-04",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1973-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q112475541",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ramiro Fernández Bachiller",
+   "title": "Ambassador of Spain to Gambia",
+   "institution": "Ambassador of Spain to Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ramiro Fernández Bachiller - Ambassador of Spain to Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2006-05-27",
+    "end_date": "2009-10-10",
+    "is_current": false,
+    "date_of_birth": "1962-04-26",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q119941327",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ramzia Diab",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ramzia Diab - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q55077373",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Richard MacDonnell",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Richard MacDonnell - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1847-12-22",
+    "end_date": "1851-01-01",
+    "is_current": false,
+    "date_of_birth": "1814-09-03",
+    "date_of_death": "1881-02-05",
+    "party": "",
+    "wikidata_qid": "Q337005",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Robert Baxter Llewelyn",
+   "title": "Administrator of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Robert Baxter Llewelyn - Administrator of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1891-01-01",
+    "end_date": "1900-01-01",
+    "is_current": false,
+    "date_of_birth": "1845-01-01",
+    "date_of_death": "1919-02-19",
+    "party": "",
+    "wikidata_qid": "Q7341945",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Rohey John Manjang",
+   "title": "Minister of Environment, Climate Change and Natural Resources",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Rohey John Manjang - Minister of Environment, Climate Change and Natural Resources",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2022-05-04",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q113326501",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sadibou Hydara",
+   "title": "Minister of the Interior",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sadibou Hydara - Minister of the Interior",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1994-01-01",
+    "end_date": "1995-01-27",
+    "is_current": false,
+    "date_of_birth": "1964-04-01",
+    "date_of_death": "1995-06-06",
+    "party": "",
+    "wikidata_qid": "Q2211138",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Saidou I. Dem",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Saidou I. Dem - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q108177431",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Saidou V. Sabally",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Saidou V. Sabally - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1968-10-27",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56333358",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Saihou S. Sabally",
+   "title": "Vice President of the Gambia",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Saihou S. Sabally - Vice President of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1992-01-01",
+    "end_date": "1994-07-22",
+    "is_current": false,
+    "date_of_birth": "1947-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q98593878",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Saihou S. Sabally",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Saihou S. Sabally - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1989-01-01",
+    "end_date": "1992-01-01",
+    "is_current": false,
+    "date_of_birth": "1947-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q98593878",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Saikou Marong",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Saikou Marong - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56235698",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Saikou Suso",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Saikou Suso - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1959-11-10",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56406040",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Saikouba Jarju",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Saikouba Jarju - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56229131",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sainey Jawara",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sainey Jawara - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "National Reconciliation Party",
+    "wikidata_qid": "Q56159570",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sainey Mbye",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sainey Mbye - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1973-04-20",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56441144",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sainey Touray",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sainey Touray - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56192624",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sait Gaye",
+   "title": "Seyfo",
+   "institution": "Seyfo",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sait Gaye - Seyfo",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q98277871",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Salifu Jawo",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Salifu Jawo - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Gambia Democratic Congress",
+    "wikidata_qid": "Q56190687",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Samba Bah",
+   "title": "Minister of the Interior",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Samba Bah - Minister of the Interior",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2004-05-04",
+    "end_date": "2005-03-29",
+    "is_current": false,
+    "date_of_birth": "1948-12-04",
+    "date_of_death": "2008-10-23",
+    "party": "",
+    "wikidata_qid": "Q2216892",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Samba Cham",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Samba Cham - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56460301",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Samba Jallow",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Samba Jallow - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "National Reconciliation Party",
+    "wikidata_qid": "Q28839661",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Samuel Rowe",
+   "title": "Administrator of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Samuel Rowe - Administrator of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1875-06-01",
+    "end_date": "1877-03-30",
+    "is_current": false,
+    "date_of_birth": "1835-03-23",
+    "date_of_death": "1888-08-28",
+    "party": "",
+    "wikidata_qid": "Q18672314",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sankung Jammeh",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sankung Jammeh - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56233493",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Seedy Keita",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Seedy Keita - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2022-05-04",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1970-11-16",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q109780728",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Seedy Keita",
+   "title": "Minister of Trade, Industry, Regional Integration and Employment",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Seedy Keita - Minister of Trade, Industry, Regional Integration and Employment",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2020-11-02",
+    "end_date": "2022-05-04",
+    "is_current": false,
+    "date_of_birth": "1970-11-16",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q109780728",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Serign Modou Njie",
+   "title": "Minister of Defence",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Serign Modou Njie - Minister of Defence",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2022-05-04",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1970-04-14",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q111972258",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Seyaka Sonko",
+   "title": "Minister of the Interior",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Seyaka Sonko - Minister of the Interior",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2022-05-04",
+    "end_date": "2024-03-15",
+    "is_current": false,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q112032364",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sharon Wardle",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sharon Wardle - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-01-01",
+    "end_date": "2020-01-01",
+    "is_current": false,
+    "date_of_birth": "1960-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q56817112",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sheikh Omar Faye",
+   "title": "Minister of Defence",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sheikh Omar Faye - Minister of Defence",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2019-08-22",
+    "end_date": "2022-05-04",
+    "is_current": false,
+    "date_of_birth": "1960-01-10",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q2277755",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sheriff Abba Sanyang",
+   "title": "Minister of Lands, Regional Government and Religious Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sheriff Abba Sanyang - Minister of Lands, Regional Government and Religious Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2022-05-04",
+    "end_date": "2023-06-26",
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56285499",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sheriff Abba Sanyang",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sheriff Abba Sanyang - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56285499",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sheriff Misba Hydara",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sheriff Misba Hydara - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56476268",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sheriff Mustapha Dibba",
+   "title": "Vice President of the Gambia",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sheriff Mustapha Dibba - Vice President of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1970-01-01",
+    "end_date": "1972-01-01",
+    "is_current": false,
+    "date_of_birth": "1937-01-10",
+    "date_of_death": "2008-06-02",
+    "party": "National Convention Party",
+    "wikidata_qid": "Q2278295",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sheriff Mustapha Dibba",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sheriff Mustapha Dibba - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1967-01-01",
+    "end_date": "1972-01-01",
+    "is_current": false,
+    "date_of_birth": "1937-01-10",
+    "date_of_death": "2008-06-02",
+    "party": "National Convention Party",
+    "wikidata_qid": "Q2278295",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sheriff S. Sisay",
+   "title": "Minister of Finance",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sheriff S. Sisay - Minister of Finance",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1982-01-01",
+    "end_date": "1989-01-01",
+    "is_current": false,
+    "date_of_birth": "1935-01-01",
+    "date_of_death": "1989-03-04",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q60055340",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Shigeru Ōmori",
+   "title": "ambassador to the Gambia",
+   "institution": "ambassador to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Shigeru Ōmori - ambassador to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1960-08-02",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q63131303",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sidia Jatta",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sidia Jatta - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1945-01-01",
+    "date_of_death": null,
+    "party": "People's Democratic Organisation for Independence and Socialism",
+    "wikidata_qid": "Q2281872",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Stephanie A. Miley",
+   "title": "United States Ambassador to the Gambia",
+   "institution": "United States Ambassador to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Stephanie A. Miley - United States Ambassador to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2024-01-01",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": null,
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q127404136",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sulayman Masanneh Ceesay",
+   "title": "Minister of the Interior",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sulayman Masanneh Ceesay - Minister of the Interior",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2003-09-29",
+    "end_date": "2004-05-04",
+    "is_current": false,
+    "date_of_birth": "1939-11-23",
+    "date_of_death": "2015-05-09",
+    "party": "",
+    "wikidata_qid": "Q28941269",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sulayman Saho",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sulayman Saho - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56183267",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sunkary Badjie",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sunkary Badjie - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56233490",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Suwaibou Touray",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Suwaibou Touray - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "People's Democratic Organisation for Independence and Socialism",
+    "wikidata_qid": "Q55979356",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Takashi Kitahara",
+   "title": "ambassador to the Gambia",
+   "institution": "ambassador to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Takashi Kitahara - ambassador to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1951-11-20",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q17157936",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Takashi Saitō",
+   "title": "ambassador to the Gambia",
+   "institution": "ambassador to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Takashi Saitō - ambassador to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1949-04-12",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q6146616",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Takeshi Akamatsu",
+   "title": "ambassador to the Gambia",
+   "institution": "ambassador to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Takeshi Akamatsu - ambassador to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1963-07-31",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q17191034",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Tamsir Jallow",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Tamsir Jallow - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1941-01-01",
+    "date_of_death": "2015-01-01",
+    "party": "",
+    "wikidata_qid": "Q2391822",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Tatsuo Arai",
+   "title": "ambassador to the Gambia",
+   "institution": "ambassador to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Tatsuo Arai - ambassador to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1956-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q56808590",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Thomas Joseph Brosnahan",
+   "title": "President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "institution": "President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Thomas Joseph Brosnahan - President of Inter-territorial Catholic Bishops' Conference of The Gambia and Sierra Leone",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1905-03-30",
+    "date_of_death": "1996-01-26",
+    "party": "",
+    "wikidata_qid": "Q52769333",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Thomas Lewis Ingram",
+   "title": "Lieutenant Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Thomas Lewis Ingram - Lieutenant Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1839-09-17",
+    "end_date": "1840-04-09",
+    "is_current": false,
+    "date_of_birth": "1807-01-01",
+    "date_of_death": "1868-01-01",
+    "party": "",
+    "wikidata_qid": "Q41590032",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Thomas Lewis Ingram",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Thomas Lewis Ingram - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1844-03-01",
+    "end_date": "1844-08-07",
+    "is_current": false,
+    "date_of_birth": "1807-01-01",
+    "date_of_death": "1868-01-01",
+    "party": "",
+    "wikidata_qid": "Q41590032",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Thomas Southorn",
+   "title": "Governor of the Gambia",
+   "institution": "list of colonial governors of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Thomas Southorn - Governor of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1936-10-22",
+    "end_date": "1942-03-23",
+    "is_current": false,
+    "date_of_birth": "1879-08-04",
+    "date_of_death": "1957-03-15",
+    "party": "",
+    "wikidata_qid": "Q2427370",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Tina Faal",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Tina Faal - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q60554755",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Tony Millson",
+   "title": "High Commissioner of the United Kingdom to the Gambia",
+   "institution": "High Commissioner of the United Kingdom to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Tony Millson - High Commissioner of the United Kingdom to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1998-01-01",
+    "end_date": "2000-01-01",
+    "is_current": false,
+    "date_of_birth": "1951-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q57820190",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Yahya Dibba",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Yahya Dibba - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q56488714",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Yahya Jammeh",
+   "title": "President of the Gambia",
+   "institution": "President of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Yahya Jammeh - President of the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1996-09-29",
+    "end_date": "2017-01-19",
+    "is_current": false,
+    "date_of_birth": "1965-05-25",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q57356",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Yahya Ngam",
+   "title": "ambassador to the Gambia",
+   "institution": "ambassador to the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Yahya Ngam - ambassador to the Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1957-06-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q135988595",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Yankuba Sonko",
+   "title": "Minister of the Interior",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Yankuba Sonko - Minister of the Interior",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2019-08-22",
+    "end_date": "2022-05-04",
+    "is_current": false,
+    "date_of_birth": "1964-05-02",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q28531806",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Yaya Gassama",
+   "title": "Member of the National Assembly of Gambia",
+   "institution": "National Assembly of The Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Yaya Gassama - Member of the National Assembly of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q56191866",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "A. K. Touray",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "A. K. Touray - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": "2002-04-26",
+    "party": "National Convention Party",
+    "wikidata_qid": "Q278318",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Aboubacar Senghore",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Aboubacar Senghore - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2013-11-01",
+    "end_date": "2014-04-09",
+    "is_current": false,
+    "date_of_birth": "1968-05-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q98590307",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Agnes Jawo",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Agnes Jawo - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q63726003",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ahzam B. Razif",
+   "title": "ambassador of Indonesia to Senegal",
+   "institution": "ambassador of Indonesia to Senegal",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ahzam B. Razif - ambassador of Indonesia to Senegal",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1947-03-20",
+    "date_of_death": "2021-10-17",
+    "party": "",
+    "wikidata_qid": "Q25460776",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alieu Badara N’Jie",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alieu Badara N’Jie - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1974-07-01",
+    "end_date": "1977-01-01",
+    "is_current": false,
+    "date_of_birth": "1904-10-17",
+    "date_of_death": "1982-04-21",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q1749174",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Alieu Badara N’Jie",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Alieu Badara N’Jie - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1904-10-17",
+    "date_of_death": "1982-04-21",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q1749174",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Almamy Touray",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Almamy Touray - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q1620155",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Amang S. Kanyi",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Amang S. Kanyi - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1900-01-01",
+    "date_of_death": "1968-09-01",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q454361",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Assan Musa Camara",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Assan Musa Camara - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1968-01-01",
+    "end_date": "1974-01-01",
+    "is_current": false,
+    "date_of_birth": "1923-04-21",
+    "date_of_death": "2013-09-15",
+    "party": "United Party",
+    "wikidata_qid": "Q739208",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Assan Musa Camara",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Assan Musa Camara - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1923-04-21",
+    "date_of_death": "2013-09-15",
+    "party": "United Party",
+    "wikidata_qid": "Q739208",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Baboucarr-Blaise Jagne",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Baboucarr-Blaise Jagne - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1995-01-01",
+    "end_date": "1997-01-01",
+    "is_current": false,
+    "date_of_birth": "1955-02-11",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q797751",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Bakary P. Camara",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bakary P. Camara - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1900-01-01",
+    "date_of_death": "1978-03-01",
+    "party": "National Convention Party",
+    "wikidata_qid": "Q804248",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Bala Garba Jahumpa",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bala Garba Jahumpa - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2006-10-26",
+    "end_date": "2007-09-01",
+    "is_current": false,
+    "date_of_birth": "1958-07-20",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q164492",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Bolong Sonko",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Bolong Sonko - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1994-01-01",
+    "end_date": "1995-01-01",
+    "is_current": false,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q891538",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Crispin Grey-Johnson",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Crispin Grey-Johnson - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2007-09-01",
+    "end_date": "2008-03-19",
+    "is_current": false,
+    "date_of_birth": "1946-12-07",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q331152",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Dawda Kairaba Jawara",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Dawda Kairaba Jawara - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1924-05-16",
+    "date_of_death": "2019-08-27",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q312716",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Dembo Bojang",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Dembo Bojang - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "National Convention Party",
+    "wikidata_qid": "Q29535468",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Dindin Wahyudin",
+   "title": "ambassador of Indonesia to Senegal",
+   "institution": "ambassador of Indonesia to Senegal",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Dindin Wahyudin - ambassador of Indonesia to Senegal",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2020-10-26",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1966-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q109437269",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Duta Kamaso",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Duta Kamaso - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q64159720",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Elizabeth Renner",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Elizabeth Renner - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1946-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q1331301",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Fafa Edrissa Mbye",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fafa Edrissa Mbye - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1942-09-18",
+    "date_of_death": "2025-03-26",
+    "party": "",
+    "wikidata_qid": "Q1316270",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Fatou Ceesay",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Fatou Ceesay - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": "2014-06-04",
+    "party": "",
+    "wikidata_qid": "Q63715043",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Haddy Nyang-Jagne",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Haddy Nyang-Jagne - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q63863224",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Hassan Bubacar Jallow",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Hassan Bubacar Jallow - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1951-08-14",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q176771",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ibrahim J. F. B. Sanyang",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ibrahim J. F. B. Sanyang - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "National Convention Party",
+    "wikidata_qid": "Q65561251",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ibrahima B. A. Kelepha-Samba",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ibrahima B. A. Kelepha-Samba - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1915-06-02",
+    "date_of_death": "1995-07-18",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q1656016",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Jerreba J. Jammeh",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Jerreba J. Jammeh - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "National Convention Party",
+    "wikidata_qid": "Q65554885",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Jerreh Daffeh",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Jerreh Daffeh - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1930-01-01",
+    "date_of_death": "1998-08-07",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q60056833",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Kebba T. Jammeh",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Kebba T. Jammeh - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1935-01-01",
+    "date_of_death": "2000-02-17",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q65554063",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lamin Kaba Bajo",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lamin Kaba Bajo - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2005-10-01",
+    "end_date": "2006-10-18",
+    "is_current": false,
+    "date_of_birth": "1964-11-10",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q174328",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lamin Kiti Jabang",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lamin Kiti Jabang - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1977-01-01",
+    "end_date": "1987-01-01",
+    "is_current": false,
+    "date_of_birth": "1942-12-12",
+    "date_of_death": null,
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q1801566",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lamin Kiti Jabang",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lamin Kiti Jabang - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1942-12-12",
+    "date_of_death": null,
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q1801566",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Louise N’Jie",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Louise N’Jie - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1922-01-23",
+    "date_of_death": "2014-05-02",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q1872177",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Lucretia St. Clair Joof",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Lucretia St. Clair Joof - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1913-01-01",
+    "date_of_death": "1982-08-01",
+    "party": "",
+    "wikidata_qid": "Q1873742",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "M. J. M. Phatty",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "M. J. M. Phatty - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q65554064",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Maba Jobe",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Maba Jobe - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2006-10-20",
+    "end_date": "2006-10-26",
+    "is_current": false,
+    "date_of_birth": "1964-01-01",
+    "date_of_death": "2023-07-12",
+    "party": "",
+    "wikidata_qid": "Q1736202",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Mamadou Tangara",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Mamadou Tangara - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2010-06-01",
+    "end_date": "2012-04-16",
+    "is_current": false,
+    "date_of_birth": "1965-06-04",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q1888110",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Mambury Njie",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Mambury Njie - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2012-04-16",
+    "end_date": "2012-08-23",
+    "is_current": false,
+    "date_of_birth": "1962-06-27",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q22006596",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Mamour Alieu Jagne",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Mamour Alieu Jagne - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2014-04-09",
+    "end_date": "2014-08-15",
+    "is_current": false,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q96690443",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Mary Alaba Mboge",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Mary Alaba Mboge - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q63758769",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Menata Njie",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Menata Njie - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q64142541",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Michael Baldeh",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Michael Baldeh - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1900-01-01",
+    "date_of_death": "1965-07-01",
+    "party": "United Party",
+    "wikidata_qid": "Q1538871",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Momadu Lamin Saho",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Momadu Lamin Saho - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1932-12-12",
+    "date_of_death": "1993-01-01",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q60074779",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Momodou Baboucar Njie",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Momodou Baboucar Njie - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1929-02-10",
+    "date_of_death": "2009-03-03",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q6897396",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Momodou Lamin Sedat Jobe",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Momodou Lamin Sedat Jobe - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1998-01-01",
+    "end_date": "2001-01-01",
+    "is_current": false,
+    "date_of_birth": "1944-07-24",
+    "date_of_death": "2025-04-06",
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q1625402",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Momodou Saidwane",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Momodou Saidwane - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "National Convention Party",
+    "wikidata_qid": "Q65581068",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Musa A. Jobe",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Musa A. Jobe - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1900-01-01",
+    "date_of_death": null,
+    "party": "United Party",
+    "wikidata_qid": "Q56271402",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Musa Drammeh",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Musa Drammeh - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q55286729",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Musa Gibril Bala Gaye",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Musa Gibril Bala Gaye - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2005-03-24",
+    "end_date": "2005-10-01",
+    "is_current": false,
+    "date_of_birth": "1946-08-13",
+    "date_of_death": "2026-01-08",
+    "party": "",
+    "wikidata_qid": "Q1953955",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ndey Njie",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ndey Njie - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1950-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q64176116",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Neneh MacDouall-Gaye",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Neneh MacDouall-Gaye - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2015-01-05",
+    "end_date": "2017-01-16",
+    "is_current": false,
+    "date_of_birth": "1957-04-08",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q1977312",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Nyimasata Sanneh-Bojang",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Nyimasata Sanneh-Bojang - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1941-01-01",
+    "date_of_death": "2015-07-15",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q2006110",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Omar M’Baki",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Omar M’Baki - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1923-01-01",
+    "date_of_death": "1994-08-27",
+    "party": "",
+    "wikidata_qid": "Q28740246",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Omar Njie",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Omar Njie - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1997-01-01",
+    "end_date": "1998-01-01",
+    "is_current": false,
+    "date_of_birth": "2000-01-01",
+    "date_of_death": "2002-09-13",
+    "party": "",
+    "wikidata_qid": "Q2023122",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Omar Sey",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Omar Sey - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1987-01-01",
+    "end_date": "1994-01-01",
+    "is_current": false,
+    "date_of_birth": "1941-02-02",
+    "date_of_death": "2018-03-02",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q2023139",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Omar Sey",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Omar Sey - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1941-02-02",
+    "date_of_death": "2018-03-02",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q2023139",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Omar Touray",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Omar Touray - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2008-03-19",
+    "end_date": "2009-09-01",
+    "is_current": false,
+    "date_of_birth": "1965-11-05",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q2023146",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ousainou Darboe",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ousainou Darboe - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2017-02-01",
+    "end_date": "2018-06-29",
+    "is_current": false,
+    "date_of_birth": "1948-08-08",
+    "date_of_death": null,
+    "party": "United Democratic Party",
+    "wikidata_qid": "Q710820",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Ousman Jammeh",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Ousman Jammeh - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2009-09-01",
+    "end_date": "2010-06-01",
+    "is_current": false,
+    "date_of_birth": "1953-08-13",
+    "date_of_death": null,
+    "party": "National Unity Party",
+    "wikidata_qid": "Q2041811",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Paul L. Baldeh",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Paul L. Baldeh - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1937-01-01",
+    "date_of_death": "1968-12-01",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q1545150",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Pierre Sarr N'Jie",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Pierre Sarr N'Jie - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1909-07-17",
+    "date_of_death": "1993-12-11",
+    "party": "United Party",
+    "wikidata_qid": "Q1262871",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Samuel Horton Jones",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Samuel Horton Jones - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1909-01-01",
+    "date_of_death": "1990-01-01",
+    "party": "",
+    "wikidata_qid": "Q67888139",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sheriff Mustapha Dibba",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sheriff Mustapha Dibba - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1937-01-10",
+    "date_of_death": "2008-06-02",
+    "party": "National Convention Party",
+    "wikidata_qid": "Q2278295",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sheriff S. Sisay",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sheriff S. Sisay - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "1967-01-01",
+    "end_date": "1968-01-01",
+    "is_current": false,
+    "date_of_birth": "1935-01-01",
+    "date_of_death": "1989-03-04",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q60055340",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sheriff S. Sisay",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sheriff S. Sisay - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1935-01-01",
+    "date_of_death": "1989-03-04",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q60055340",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Sidi Moro Sanneh",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Sidi Moro Sanneh - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2004-10-14",
+    "end_date": "2005-03-24",
+    "is_current": false,
+    "date_of_birth": "1947-12-02",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q2281867",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Susan Waffa-Ogoo",
+   "title": "Minister of Foreign Affairs",
+   "institution": "Cabinet of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Susan Waffa-Ogoo - Minister of Foreign Affairs",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2012-11-02",
+    "end_date": "2013-10-30",
+    "is_current": false,
+    "date_of_birth": "1960-10-04",
+    "date_of_death": null,
+    "party": "Alliance for Patriotic Reorientation and Construction",
+    "wikidata_qid": "Q2368962",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Tamba Jammeh",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Tamba Jammeh - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1890-01-01",
+    "date_of_death": "1987-10-13",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q67222688",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Yaya Ceesay",
+   "title": "Member of the House of Representatives of Gambia",
+   "institution": "House of Representatives of the Gambia",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Yaya Ceesay - Member of the House of Representatives of Gambia",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": null,
+    "end_date": null,
+    "is_current": false,
+    "date_of_birth": "1936-01-01",
+    "date_of_death": "2026-05-02",
+    "party": "People's Progressive Party",
+    "wikidata_qid": "Q60063834",
+    "wikidata_country_qid": "Q1005"
+   }
+  },
+  {
+   "full_name": "Javier Calderón Raya",
+   "title": "delegate of the Government of the Generalitat of Catalonia in Western Africa",
+   "institution": "delegate of the Government of the Generalitat of Catalonia in Western Africa",
+   "country_code": "GM",
+   "source_url": "https://www.wikidata.org/wiki/Q1005",
+   "source_type": "WIKIDATA",
+   "raw_text": "Javier Calderón Raya - delegate of the Government of the Generalitat of Catalonia in Western Africa",
+   "scraped_at": "2026-07-13T14:29:28.612929+00:00",
+   "extra_fields": {
+    "start_date": "2022-04-05",
+    "end_date": null,
+    "is_current": true,
+    "date_of_birth": "1976-01-01",
+    "date_of_death": null,
+    "party": "",
+    "wikidata_qid": "Q136098215",
+    "wikidata_country_qid": "Q1005"
+   }
+  }
+ ],
+ "relationships": [
+  {
+   "person_qid": "Q64010186",
+   "person_name": "Ahmed Afif",
+   "related_name": "Abdullah Afeef",
+   "relationship_type": "FATHER"
+  },
+  {
+   "person_qid": "Q111828605",
+   "person_name": "António Correia Sumbana",
+   "related_name": "Fernando Sumbana",
+   "relationship_type": "SIBLING"
+  },
+  {
+   "person_qid": "Q651599",
+   "person_name": "Arthur Grimble",
+   "related_name": "Rosemary Grimble",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q5081298",
+   "person_name": "Charles O'Brien",
+   "related_name": "Selina Beatrice Elphinstone",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q5081298",
+   "person_name": "Charles O'Brien",
+   "related_name": "Sir Terence O'Brien",
+   "relationship_type": "FATHER"
+  },
+  {
+   "person_qid": "Q18351656",
+   "person_name": "Dick Carlson",
+   "related_name": "Tucker Carlson",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q18351656",
+   "person_name": "Dick Carlson",
+   "related_name": "Buckley Carlson",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q18351656",
+   "person_name": "Dick Carlson",
+   "related_name": "Patricia Caroline Swanson",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q18351656",
+   "person_name": "Dick Carlson",
+   "related_name": "Lisa McNear",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q7526658",
+   "person_name": "Eustace Fiennes",
+   "related_name": "Sir Ranulph Twisleton-Wykeham-Fiennes, 2nd Bt.",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q7526658",
+   "person_name": "Eustace Fiennes",
+   "related_name": "John Eustace Twisleton-Wykeham-Fiennes",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q7526658",
+   "person_name": "Eustace Fiennes",
+   "related_name": "Lady Augusta Sophia Hay-Drummond",
+   "relationship_type": "MOTHER"
+  },
+  {
+   "person_qid": "Q7526658",
+   "person_name": "Eustace Fiennes",
+   "related_name": "Florence Agnes Rathfelder",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q7526658",
+   "person_name": "Eustace Fiennes",
+   "related_name": "John Twisleton-Wykeham-Fiennes, 17th Baron Saye and Sele",
+   "relationship_type": "FATHER"
+  },
+  {
+   "person_qid": "Q101830187",
+   "person_name": "Hazem Shabat",
+   "related_name": "Safa Khaldi",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q6169248",
+   "person_name": "Jean-François Ferrari",
+   "related_name": "Maxime Ferrari",
+   "relationship_type": "FATHER"
+  },
+  {
+   "person_qid": "Q335797",
+   "person_name": "Julian Asquith, 2nd Earl of Oxford and Asquith",
+   "related_name": "Dominic Asquith",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q335797",
+   "person_name": "Julian Asquith, 2nd Earl of Oxford and Asquith",
+   "related_name": "Raymond Asquith, 3rd Earl of Oxford and Asquith",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q335797",
+   "person_name": "Julian Asquith, 2nd Earl of Oxford and Asquith",
+   "related_name": "Lady Mary Annunziata Asquith",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q335797",
+   "person_name": "Julian Asquith, 2nd Earl of Oxford and Asquith",
+   "related_name": "Lady Katharine Asquith",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q335797",
+   "person_name": "Julian Asquith, 2nd Earl of Oxford and Asquith",
+   "related_name": "Lady Clare Asquith",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q335797",
+   "person_name": "Julian Asquith, 2nd Earl of Oxford and Asquith",
+   "related_name": "Katharine Asquith",
+   "relationship_type": "MOTHER"
+  },
+  {
+   "person_qid": "Q335797",
+   "person_name": "Julian Asquith, 2nd Earl of Oxford and Asquith",
+   "related_name": "Anne Asquith",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q335797",
+   "person_name": "Julian Asquith, 2nd Earl of Oxford and Asquith",
+   "related_name": "Raymond Asquith",
+   "relationship_type": "FATHER"
+  },
+  {
+   "person_qid": "Q335797",
+   "person_name": "Julian Asquith, 2nd Earl of Oxford and Asquith",
+   "related_name": "Lady Perdita Asquith",
+   "relationship_type": "SIBLING"
+  },
+  {
+   "person_qid": "Q335797",
+   "person_name": "Julian Asquith, 2nd Earl of Oxford and Asquith",
+   "related_name": "Lady Helen Asquith",
+   "relationship_type": "SIBLING"
+  },
+  {
+   "person_qid": "Q457392",
+   "person_name": "Selwyn Selwyn-Clarke",
+   "related_name": "Hilda Selwyn-Clarke",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q3565744",
+   "person_name": "Walter Edward Davidson",
+   "related_name": "Margaret Davidson",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q1568174",
+   "person_name": "Wavel Ramkalawan",
+   "related_name": "Linda Ramkalawan",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q108649202",
+   "person_name": "William Addis",
+   "related_name": "William Stewart Addis",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q108649202",
+   "person_name": "William Addis",
+   "related_name": "Richard Thomas Addis",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q108649202",
+   "person_name": "William Addis",
+   "related_name": "Elizabeth Jane McIsaac",
+   "relationship_type": "MOTHER"
+  },
+  {
+   "person_qid": "Q108649202",
+   "person_name": "William Addis",
+   "related_name": "Rosemary Gardner",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q108649202",
+   "person_name": "William Addis",
+   "related_name": "Charles Addis",
+   "relationship_type": "FATHER"
+  },
+  {
+   "person_qid": "Q27917049",
+   "person_name": "Adama Barrow",
+   "related_name": "Fatoumatta Bah-Barrow",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q2848165",
+   "person_name": "André Lewin",
+   "related_name": "Catherine Clément",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q330140",
+   "person_name": "Arthur Kennedy",
+   "related_name": "Grace Dorothea Hughes",
+   "relationship_type": "MOTHER"
+  },
+  {
+   "person_qid": "Q330140",
+   "person_name": "Arthur Kennedy",
+   "related_name": "Georgina Mildred Macartney",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q330140",
+   "person_name": "Arthur Kennedy",
+   "related_name": "Elizabeth Kennedy",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q330140",
+   "person_name": "Arthur Kennedy",
+   "related_name": "George Kennedy",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q330140",
+   "person_name": "Arthur Kennedy",
+   "related_name": "Georgina Kennedy",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q330140",
+   "person_name": "Arthur Kennedy",
+   "related_name": "Hugh Kennedy",
+   "relationship_type": "FATHER"
+  },
+  {
+   "person_qid": "Q711119",
+   "person_name": "Arthur Richards, 1st Baron Milverton",
+   "related_name": "Noelle Benda Whitehead",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q711119",
+   "person_name": "Arthur Richards, 1st Baron Milverton",
+   "related_name": "Fraser Richards, 2nd Baron Milverton",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q711119",
+   "person_name": "Arthur Richards, 1st Baron Milverton",
+   "related_name": "Michael Hugh Richards",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q711119",
+   "person_name": "Arthur Richards, 1st Baron Milverton",
+   "related_name": "Diana Benda Richards",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q711119",
+   "person_name": "Arthur Richards, 1st Baron Milverton",
+   "related_name": "William Richards",
+   "relationship_type": "FATHER"
+  },
+  {
+   "person_qid": "Q7401008",
+   "person_name": "Chiyuki Hiraoka",
+   "related_name": "Shizue Hiraoka",
+   "relationship_type": "MOTHER"
+  },
+  {
+   "person_qid": "Q7401008",
+   "person_name": "Chiyuki Hiraoka",
+   "related_name": "Yukio Mishima",
+   "relationship_type": "SIBLING"
+  },
+  {
+   "person_qid": "Q7401008",
+   "person_name": "Chiyuki Hiraoka",
+   "related_name": "Mitsuko Hiraoka",
+   "relationship_type": "SIBLING"
+  },
+  {
+   "person_qid": "Q7401008",
+   "person_name": "Chiyuki Hiraoka",
+   "related_name": "Azusa Hiraoka",
+   "relationship_type": "FATHER"
+  },
+  {
+   "person_qid": "Q1133823",
+   "person_name": "Cornelius Hendricksen Kortright",
+   "related_name": "Guy Kortright",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q312716",
+   "person_name": "Dawda Kairaba Jawara",
+   "related_name": "Augusta Jawara",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q312716",
+   "person_name": "Dawda Kairaba Jawara",
+   "related_name": "Chilel Jawara",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q1291745",
+   "person_name": "Edward Brandis Denham",
+   "related_name": "John Bovill Denham",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q28935482",
+   "person_name": "Edward Windley",
+   "related_name": "Florence de Toustain, Vicomtesse de Toustain",
+   "relationship_type": "MOTHER"
+  },
+  {
+   "person_qid": "Q28935482",
+   "person_name": "Edward Windley",
+   "related_name": "Patience Ann Sergison-Brooke",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q28935482",
+   "person_name": "Edward Windley",
+   "related_name": "Davinia Windley",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q28935482",
+   "person_name": "Edward Windley",
+   "related_name": "Edward Crosland Windley",
+   "relationship_type": "FATHER"
+  },
+  {
+   "person_qid": "Q5859957",
+   "person_name": "Fernando Morán Calvo-Sotelo",
+   "related_name": "María de la Luz Calvo-Sotelo",
+   "relationship_type": "MOTHER"
+  },
+  {
+   "person_qid": "Q5859957",
+   "person_name": "Fernando Morán Calvo-Sotelo",
+   "related_name": "Fernando Morán López",
+   "relationship_type": "FATHER"
+  },
+  {
+   "person_qid": "Q19059378",
+   "person_name": "George Chardin Denton",
+   "related_name": "Jean Margaret Alan Denton",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q1524074",
+   "person_name": "Gilbert Thomas Carter",
+   "related_name": "Gertrude Carter",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q54637664",
+   "person_name": "Habib Saihou Drammeh",
+   "related_name": "Amie Bensouda",
+   "relationship_type": "SIBLING"
+  },
+  {
+   "person_qid": "Q204631",
+   "person_name": "Henry Galway",
+   "related_name": "Alicia Dorinda MacDougall",
+   "relationship_type": "MOTHER"
+  },
+  {
+   "person_qid": "Q204631",
+   "person_name": "Henry Galway",
+   "related_name": "Marie Galway",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q204631",
+   "person_name": "Henry Galway",
+   "related_name": "Sir Thomas Lionel John Gallwey",
+   "relationship_type": "FATHER"
+  },
+  {
+   "person_qid": "Q5735394",
+   "person_name": "Herbert Richmond Palmer",
+   "related_name": "Margaret Isabel Abel Smith",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q5735394",
+   "person_name": "Herbert Richmond Palmer",
+   "related_name": "Virginia Katherine Palmer",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q5735394",
+   "person_name": "Herbert Richmond Palmer",
+   "related_name": "Jenifer Myrtle Palmer",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q1681090",
+   "person_name": "James Shaw Hay",
+   "related_name": "Georgette Heine Arnaud",
+   "relationship_type": "MOTHER"
+  },
+  {
+   "person_qid": "Q1681090",
+   "person_name": "James Shaw Hay",
+   "related_name": "Jane Morin",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q1681090",
+   "person_name": "James Shaw Hay",
+   "related_name": "Isabella Graham Cockburn",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q1681090",
+   "person_name": "James Shaw Hay",
+   "related_name": "Frances Marie Polatza",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q1681090",
+   "person_name": "James Shaw Hay",
+   "related_name": "Margaret Eleanor Hay",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q1681090",
+   "person_name": "James Shaw Hay",
+   "related_name": "Thomas Pasley Hay",
+   "relationship_type": "FATHER"
+  },
+  {
+   "person_qid": "Q1872177",
+   "person_name": "Louise N’Jie",
+   "related_name": "Augusta Jawara",
+   "relationship_type": "SIBLING"
+  },
+  {
+   "person_qid": "Q1872177",
+   "person_name": "Louise N’Jie",
+   "related_name": "Hannah Mahoney",
+   "relationship_type": "MOTHER"
+  },
+  {
+   "person_qid": "Q2041817",
+   "person_name": "Ousman Koro Ceesay",
+   "related_name": "Fatou Ceesay",
+   "relationship_type": "MOTHER"
+  },
+  {
+   "person_qid": "Q337005",
+   "person_name": "Richard MacDonnell",
+   "related_name": "Jane Graves",
+   "relationship_type": "MOTHER"
+  },
+  {
+   "person_qid": "Q337005",
+   "person_name": "Richard MacDonnell",
+   "related_name": "Arthur Robert MacDonnell",
+   "relationship_type": "SIBLING"
+  },
+  {
+   "person_qid": "Q337005",
+   "person_name": "Richard MacDonnell",
+   "related_name": "Blanche Ann Skurray",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q337005",
+   "person_name": "Richard MacDonnell",
+   "related_name": "Richard MacDonnell",
+   "relationship_type": "FATHER"
+  },
+  {
+   "person_qid": "Q2278295",
+   "person_name": "Sheriff Mustapha Dibba",
+   "related_name": "Kutubo Mustapha Dibba",
+   "relationship_type": "SIBLING"
+  },
+  {
+   "person_qid": "Q60055340",
+   "person_name": "Sheriff S. Sisay",
+   "related_name": "Hawa Sisay-Sabally",
+   "relationship_type": "CHILD"
+  },
+  {
+   "person_qid": "Q2427370",
+   "person_name": "Thomas Southorn",
+   "related_name": "Bella Woolf",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q57356",
+   "person_name": "Yahya Jammeh",
+   "related_name": "Zeineb Jammeh",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q57356",
+   "person_name": "Yahya Jammeh",
+   "related_name": "Tuti Faal",
+   "relationship_type": "SPOUSE"
+  },
+  {
+   "person_qid": "Q57356",
+   "person_name": "Yahya Jammeh",
+   "related_name": "Asombi Bojang",
+   "relationship_type": "MOTHER"
+  }
+ ]
+}

--- a/africapep/database/seed_sample.py
+++ b/africapep/database/seed_sample.py
@@ -1,0 +1,114 @@
+"""Seed the database from the bundled offline sample dataset.
+
+Run with: python -m africapep.database.seed_sample
+
+Loads real Wikidata records for two countries (Seychelles and Gambia,
+captured 2026-07-13) from sample_data.json and pushes them through the
+exact same pipeline as the full seed: normalise -> classify -> resolve ->
+Neo4j -> PostgreSQL sync. No network access required.
+
+Use this to get a populated local API in under a minute. For the full
+54-country dataset, run: python -m africapep.database.seed
+"""
+import json
+from datetime import datetime
+from pathlib import Path
+
+import structlog
+
+from africapep.scraper.base_scraper import RawPersonRecord
+from africapep.scraper.spiders.wikidata_scraper import WikidataRelationship
+
+log = structlog.get_logger()
+
+SAMPLE_PATH = Path(__file__).parent / "sample_data.json"
+
+
+def load_sample() -> tuple[list[RawPersonRecord], list[WikidataRelationship]]:
+    """Load the bundled sample dataset from disk."""
+    with open(SAMPLE_PATH, encoding="utf-8") as f:
+        data = json.load(f)
+
+    records = []
+    for d in data["records"]:
+        d = dict(d)
+        d["scraped_at"] = datetime.fromisoformat(d["scraped_at"])
+        records.append(RawPersonRecord(**d))
+
+    relationships = [WikidataRelationship(**r) for r in data["relationships"]]
+    return records, relationships
+
+
+def main():
+    # DB-touching imports stay local so load_sample() is importable
+    # (and testable) without database drivers installed.
+    from africapep.pipeline.normaliser import normalise_record
+    from africapep.pipeline.classifier import classify_pep_tier
+    from africapep.pipeline.resolver import EntityResolver
+    from africapep.database.neo4j_client import neo4j_client
+    from africapep.database.sync import sync_all
+    from africapep.database.seed import _find_person_by_name
+
+    print("=" * 50)
+    print("  AfricaPEP Sample Seed (offline)")
+    print("  Source: bundled sample_data.json (SC + GM)")
+    print("=" * 50)
+    print()
+
+    records, relationships = load_sample()
+    print(f"  Loaded {len(records)} records, {len(relationships)} relationships")
+
+    resolver = EntityResolver()
+    for record in records:
+        normalised = normalise_record(record)
+        tier = classify_pep_tier(normalised.title, normalised.institution)
+        resolver.add(normalised, tier)
+
+    stats = resolver.get_stats()
+    print(f"  Resolved entities: {stats['total_entities']}")
+    print(f"  Duplicates merged: {stats['potential_duplicates']}")
+
+    print("  Writing to Neo4j...")
+    written = resolver.flush_to_neo4j(neo4j_client)
+    print(f"    Written {written} entities")
+
+    known_persons: dict[str, str] = {}
+    for entity in resolver.entities.values():
+        known_persons[entity.full_name] = entity.id
+        for variant in entity.name_variants:
+            if variant not in known_persons:
+                known_persons[variant] = entity.id
+
+    qid_to_entity = resolver._qid_to_entity
+
+    linked = 0
+    for rel in relationships:
+        person_entity_id = qid_to_entity.get(rel.person_qid)
+        if not person_entity_id:
+            continue
+        related_entity_id = _find_person_by_name(rel.related_name, known_persons)
+        if related_entity_id:
+            if rel.relationship_type in ("SPOUSE", "CHILD", "SIBLING", "FATHER", "MOTHER"):
+                neo4j_client.link_family(person_entity_id, related_entity_id, rel.relationship_type)
+            else:
+                neo4j_client.link_associate(person_entity_id, related_entity_id, rel.relationship_type)
+            linked += 1
+    print(f"    Linked {linked} relationships")
+
+    print("  Syncing to PostgreSQL...")
+    synced = sync_all()
+    print(f"    Synced {synced} profiles")
+
+    print()
+    print("=" * 50)
+    print("  Sample seed complete. Try:")
+    print('  curl -X POST http://localhost:8000/api/v1/screen \\')
+    print('    -H "Content-Type: application/json" \\')
+    print('    -d \'{"name": "Adama Barrow"}\'')
+    print("=" * 50)
+
+    neo4j_client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_seed_sample.py
+++ b/tests/test_seed_sample.py
@@ -1,0 +1,31 @@
+"""Tests for the bundled offline sample dataset."""
+from africapep.database.seed_sample import load_sample
+
+
+def test_sample_loads():
+    records, relationships = load_sample()
+    assert len(records) >= 400
+    assert len(relationships) >= 50
+
+
+def test_sample_covers_two_countries():
+    records, _ = load_sample()
+    countries = {r.country_code for r in records}
+    assert countries == {"SC", "GM"}
+
+
+def test_sample_records_are_complete():
+    records, _ = load_sample()
+    for r in records:
+        assert r.full_name
+        assert r.title
+        assert r.source_url.startswith("https://")
+        assert r.scraped_at is not None
+
+
+def test_sample_relationships_reference_types():
+    _, relationships = load_sample()
+    allowed = {"SPOUSE", "CHILD", "SIBLING", "FATHER", "MOTHER"}
+    for rel in relationships:
+        assert rel.person_qid.startswith("Q")
+        assert rel.relationship_type in allowed


### PR DESCRIPTION
New contributors currently need a full live Wikidata scrape (54 countries, polite delays, many minutes, network-dependent) before the API returns anything. This bundles a 356KB fixture of 510 real records + 89 relationships (Seychelles + Gambia, captured today with the production scraper) and a `make seed-sample` target that runs them through the exact same pipeline offline.

Partially addresses #14 (the sample-data half; the one-command compose UX half remains open).

Verification: ruff clean, 151 tests passing including 4 new fixture-integrity tests.