### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to AfricaPEP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-07-13
+
+### Added
+- Phonetic name matching (Double Metaphone via jellyfish) alongside orthographic scoring, with a QID-grounded evaluation harness (#26)
+- Offline Splink probabilistic dedup pass with AML-safe merge policy: auto-merge only at >=0.99 probability with corroboration, review queue below (#27)
+- Expanded Wikidata catchment for low-coverage countries via three isolated SPARQL branches (country, jurisdiction, citizenship) (#23)
+- Comprehensive public API guide at docs/API.md, covering auth, validation rules, rate limits, and error formats (#30, contributed by @Atharv-AC)
+- Bundled offline sample dataset (510 real records, Seychelles + Gambia) and `make seed-sample` for a populated local API in under a minute (#35)
+- ROADMAP.md, CONTRIBUTING-DATA.md (non-code contribution guide), and a country data validation issue template (#33)
+- requirements-dev.txt for development tooling (#34)
+
+### Fixed
+- Cross-run Person node duplication: node ids now derive deterministically from Wikidata QIDs (#24)
+- Per-run Position/Organisation node duplication: content-derived ids (#32)
+- Splink false-merging non-Latin names that produced empty metaphone keys (#28)
+- Scraper SPARQL timeout too low for the citizenship catchment branch (#25)
+- CI red on every push due to two lint errors; entity resolution tests (20) were silently excluded from the default pytest run and now run in CI (#31)
+
+### Changed
+- Public claims reconciled with reality: 34,000+ profiles and 170+ tests stated consistently across README, badges, and the OpenAPI description (#33)
+- README states plainly that Wikidata is the sole current data source via one parameterized scraper; national sources are framed as contribution opportunities (#33)
+- Removed dead scaffolding never wired into the pipeline (Playwright utils, proxy rotator, PDF parser, spaCy NER extractor and relationship builder, unused ORM models) and pruned seven unused dependencies; Docker image loses two spaCy models and tesseract, CI runs ~40% faster (#34)
+
+### Security
+- requests bumped to 2.32.3 (CVE-2024-35195) (#33)
+- Production docker-compose now fails loudly when database passwords are unset instead of defaulting to `changeme` (#33)
+- API key comparison uses constant-time `secrets.compare_digest` (#33)
+- Per-worker in-memory rate limit behaviour documented as a known caveat (#33, tracked for Redis in #38)
+
 ## [1.0.0] - 2026-03-08
 
 ### Added

--- a/africapep/api/main.py
+++ b/africapep/api/main.py
@@ -45,7 +45,7 @@ app = FastAPI(
         "- **FATF-aligned Tiers** — Tier 1 (heads of state), Tier 2 (MPs/judges), Tier 3 (local officials)\n"
         "- **Dual Database** — Neo4j graph + PostgreSQL for fast search\n"
     ),
-    version="1.0.0",
+    version="1.1.0",
     docs_url=None if is_production else "/docs",
     redoc_url=None if is_production else "/redoc",
     openapi_url=None if is_production else "/openapi.json",
@@ -225,6 +225,6 @@ app.include_router(countries.router, prefix="/api/v1", tags=["Countries"])
 def root():
     return {
         "service": "AfricaPEP API",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "docs": "/docs",
     }

--- a/africapep/api/routers/health.py
+++ b/africapep/api/routers/health.py
@@ -26,5 +26,5 @@ async def health_check():
         status=overall,
         neo4j=neo4j_status,
         postgres=pg_status,
-        version="1.0.0",
+        version="1.1.0",
     )

--- a/africapep/api/schemas.py
+++ b/africapep/api/schemas.py
@@ -223,13 +223,13 @@ class HealthResponse(BaseModel):
     status: str
     neo4j: str
     postgres: str
-    version: str = "1.0.0"
+    version: str = "1.1.0"
 
     model_config = {"json_schema_extra": {"examples": [{
         "status": "healthy",
         "neo4j": "connected",
         "postgres": "connected",
-        "version": "1.0.0",
+        "version": "1.1.0",
     }]}}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "africapep"
-version = "1.0.0"
+version = "1.1.0"
 description = "Open-source African PEP (Politically Exposed Persons) database with scrapers, NLP pipeline, and API"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Version bump + CHANGELOG for the v1.1.0 release. See CHANGELOG.md for the full list: phonetic matching, Splink dedup pass, node duplication fixes, offline sample seed, API docs, claims reconciliation, and security hardening.