### PR TITLE
feat: one-command quickstart, matching quality metrics, weekly production smoke check

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,40 @@
+name: Production smoke check
+
+# Runs Monday mornings, a few hours after the Sunday 02:00 UTC scrape/sync
+# jobs, so a scrape that broke the database surfaces as a red workflow and
+# an email instead of waiting for a user to notice.
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Health endpoint
+        run: |
+          body=$(curl -sf --max-time 30 https://api-pep.patrickaiafrica.com/health)
+          echo "$body"
+          echo "$body" | grep -q '"status":"healthy"'
+          echo "$body" | grep -q '"neo4j":"connected"'
+          echo "$body" | grep -q '"postgres":"connected"'
+
+      - name: Profile count sanity
+        run: |
+          count=$(curl -sf --max-time 30 https://api-pep.patrickaiafrica.com/api/v1/stats | python3 -c "import sys,json;print(json.load(sys.stdin)['total_peps'])")
+          echo "total_peps=$count"
+          # The database only grows (positions are end-dated, never deleted).
+          # A count below 30000 means a scrape or sync destroyed data.
+          test "$count" -ge 30000
+
+      - name: Screening round-trip
+        run: |
+          matches=$(curl -sf --max-time 30 -X POST https://api-pep.patrickaiafrica.com/api/v1/screen \
+            -H "Content-Type: application/json" \
+            -d '{"name": "John Mahama", "threshold": 0.85}' | python3 -c "import sys,json;print(json.load(sys.stdin)['total_matches'])")
+          echo "matches=$matches"
+          test "$matches" -ge 1

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 quickstart:
 	cp -n .env.example .env || true
-	docker compose up -d --wait
+	docker compose up -d --wait api
+	docker compose up -d
 	docker compose exec api python -m africapep.database.init
 	docker compose exec api python -m africapep.database.seed_sample
 	@echo ""
@@ -11,7 +12,8 @@ quickstart:
 
 setup:
 	cp -n .env.example .env || true
-	docker compose up -d --wait
+	docker compose up -d --wait api
+	docker compose up -d
 	docker compose exec api python -m africapep.database.init
 
 run:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,17 @@
-.PHONY: setup run seed seed-sample test clean
+.PHONY: quickstart setup run seed seed-sample test clean
+
+quickstart:
+	cp -n .env.example .env || true
+	docker compose up -d --wait
+	docker compose exec api python -m africapep.database.init
+	docker compose exec api python -m africapep.database.seed_sample
+	@echo ""
+	@echo "Done. A populated API is running at http://localhost:8000"
+	@echo "Try: curl -X POST http://localhost:8000/api/v1/screen -H 'Content-Type: application/json' -d '{\"name\": \"Adama Barrow\"}'"
 
 setup:
 	cp -n .env.example .env || true
-	docker compose up -d
+	docker compose up -d --wait
 	docker compose exec api python -m africapep.database.init
 
 run:

--- a/README.md
+++ b/README.md
@@ -102,24 +102,22 @@ Wikidata is currently the sole data source, queried through one parameterized SP
 
 ## Quick Start
 
-We've provided a simple `Makefile` to get the project running via Docker in minutes!
+One command from clone to a working, populated screening API:
 
 ```bash
-# 1. Clone the repository
 git clone https://github.com/PatrickAttankurugu/AfricaPEP.git && cd AfricaPEP
+make quickstart
+```
 
-# 2. Setup the environment and start services
-make setup
+That boots Neo4j + PostgreSQL + the API, applies schema, and seeds the bundled offline sample dataset (2 countries, ~500 real records, no live scraping). Takes 2-3 minutes on a cold clone, most of it the Docker image build.
 
-# 3a. Quick start: seed with the bundled offline sample (2 countries, ~500 records, under a minute)
-make seed-sample
-
-# 3b. Or seed with live PEP data from Wikidata (all 54 countries, 34,000+ profiles, takes a while)
-make seed
-
-# 4. Success! API is live at http://localhost:8000
+```bash
+# Verify
 curl http://localhost:8000/health
 curl -X POST http://localhost:8000/api/v1/screen -H "Content-Type: application/json" -d '{"name": "Adama Barrow"}'
+
+# When you want the full dataset: live-seed all 54 countries from Wikidata (34,000+ profiles, takes a while)
+make seed
 ```
 
 ## Local Development (Hot-Reload)

--- a/README.md
+++ b/README.md
@@ -265,6 +265,23 @@ python -c "from africapep.database.sync import sync_all; sync_all()"
    - Score < 0.70 -> Separate entities
 4. **Merging:** All source records preserved. Name variants accumulated. Most restrictive PEP tier kept.
 
+## Matching Quality
+
+Name matching is measured, not asserted. A QID-grounded evaluation harness (`scripts/eval_name_matching.py`) scores the real production rules against labeled pairs where ground truth comes from Wikidata QIDs, including deliberately hard cases: transliterations (Mohammed/Muhammad), diacritics, and different people who share a blocking bucket.
+
+Current results on the 23-pair adversarial fixture:
+
+| Rule | Precision | Recall | F1 |
+|------|-----------|--------|-----|
+| Screening (threshold 0.75, recall-first) | 0.71 | 1.00 | 0.83 |
+| High threshold 0.90, orthographic only | 0.91 | 0.83 | 0.87 |
+| High threshold 0.90, + phonetic | 0.92 | 1.00 | 0.96 |
+| Auto-merge gate (orthographic >= 0.85) | 0.92 | 1.00 | 0.96 |
+
+Two design decisions fall straight out of these numbers: screening is deliberately recall-first (a compliance analyst reviews candidates; a missed PEP is worse than a false candidate), while merging is precision-first with corroboration required for phonetic-only matches (a false merge could flag an innocent person).
+
+The fixture set is small and grows by contribution: if you know name variants from your country that should (or should not) match, adding labeled pairs to `tests/fixtures/name_match_pairs.json` is a five-minute contribution that directly hardens the matcher. Run the harness with `python scripts/eval_name_matching.py`.
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
Three pre-launch items:

**`make quickstart`** (closes #14): one command from cold clone to a populated screening API. Boots the stack healthcheck-gated (`--wait` on the api service, which gates its db dependencies), applies schema, runs the offline sample seed. E2E-tested from a genuinely cold clone on a clean host: clone -> quickstart -> screening 'Adama Barrow' returns a 1.0 match in ~3 minutes.

**Matching Quality README section**: publishes measured precision/recall from the QID-grounded eval harness, honestly framed as a 23-pair adversarial fixture, with the design rationale (recall-first screening, precision-first merging) and a five-minute contribution path (add labeled pairs).

**Weekly production smoke check**: scheduled workflow Monday 06:00 UTC (a few hours after the Sunday scrape/sync) verifying health, a 30k profile-count floor, and a screening round-trip, so a scrape that breaks production emails you instead of waiting for a user to notice.