### PR TITLE
fix: position term dates from rel + collapse parallel rels in dedup

### DIFF
--- a/africapep/api/routers/pep.py
+++ b/africapep/api/routers/pep.py
@@ -31,14 +31,19 @@ async def get_pep_profile(pep_id: str):
         pos = pos_data.get("position")
         if pos:
             held = pos_data.get("held", {}) or {}
+            # Term dates belong to the HELD_POSITION relationship. Position
+            # nodes are shared across holders (content-derived ids), so any
+            # dates on the node are one arbitrary holder's term.
+            start = held.get("start_date") or pos.get("start_date")
+            end = held.get("end_date") or pos.get("end_date")
             positions.append(PositionResponse(
                 title=pos.get("title", ""),
                 institution=pos.get("institution", ""),
                 country=pos.get("country", ""),
                 flag=country_flag(pos.get("country", "")),
                 branch=pos.get("branch", ""),
-                start_date=str(pos.get("start_date")) if pos.get("start_date") else None,
-                end_date=str(pos.get("end_date")) if pos.get("end_date") else None,
+                start_date=str(start) if start else None,
+                end_date=str(end) if end else None,
                 is_current=held.get("is_current", pos.get("is_current", True)),
             ))
 

--- a/scripts/dedup_positions.py
+++ b/scripts/dedup_positions.py
@@ -83,18 +83,14 @@ def dedup_positions(session, dry_run: bool) -> tuple[int, int]:
             )
             keeper = canonical
 
-        # Re-point HELD_POSITION, preserving properties; a rel with the same
-        # period on the keeper counts as already present (identical periods
-        # collapse, distinct terms survive).
+        # Re-point HELD_POSITION unconditionally, preserving properties.
+        # A NOT EXISTS guard here does NOT reliably see this statement's own
+        # earlier CREATEs, so duplicates are collapsed in a dedicated pass
+        # afterwards (collapse_parallel_rels) instead of being prevented here.
         session.run("""
             UNWIND $dups AS did
             MATCH (person:Person)-[r:HELD_POSITION]->(dup:Position {id: did})
             MATCH (keep:Position {id: $keeper})
-            WHERE NOT EXISTS {
-                MATCH (person)-[k:HELD_POSITION]->(keep)
-                WHERE coalesce(k.start_date, '') = coalesce(r.start_date, '')
-                  AND coalesce(k.end_date, '') = coalesce(r.end_date, '')
-            }
             CREATE (person)-[nk:HELD_POSITION]->(keep)
             SET nk = properties(r)
         """, {"dups": dups, "keeper": keeper})
@@ -115,6 +111,31 @@ def dedup_positions(session, dry_run: bool) -> tuple[int, int]:
         removed += len(dups)
 
     return len(groups), removed
+
+
+def collapse_parallel_rels(session, dry_run: bool) -> int:
+    """Collapse parallel HELD_POSITION rels with identical properties.
+
+    Distinct terms (different start/end) are different property maps and
+    survive as separate relationships.
+    """
+    if dry_run:
+        result = session.run("""
+            MATCH (p:Person)-[r:HELD_POSITION]->(pos:Position)
+            WITH p, pos, properties(r) AS props, collect(r) AS rs
+            WHERE size(rs) > 1
+            RETURN sum(size(rs) - 1) AS extras
+        """).single()
+        return result["extras"] or 0
+
+    result = session.run("""
+        MATCH (p:Person)-[r:HELD_POSITION]->(pos:Position)
+        WITH p, pos, properties(r) AS props, collect(r) AS rs
+        WHERE size(rs) > 1
+        FOREACH (x IN rs[1..] | DELETE x)
+        RETURN sum(size(rs) - 1) AS extras
+    """).single()
+    return result["extras"] or 0
 
 
 def dedup_organisations(session, dry_run: bool) -> tuple[int, int]:
@@ -182,6 +203,9 @@ def main():
 
     with driver.session() as session:
         pos_groups, pos_removed = dedup_positions(session, args.dry_run)
+        rels_collapsed = collapse_parallel_rels(session, args.dry_run)
+        print(f"Parallel identical HELD_POSITION rels "
+              f"{'to collapse' if args.dry_run else 'collapsed'}: {rels_collapsed}")
         org_groups, org_removed = dedup_organisations(session, args.dry_run)
 
         totals = session.run("""


### PR DESCRIPTION
Two follow-ups from running #54 against production:

1. **Profile dates were wrong after node dedup**: Position nodes are now shared across holders, so the node-level start/end dates that pep.py displayed belong to one arbitrary holder (John Mahama's profile showed a 1969-70 presidential term). Term dates live on the HELD_POSITION relationship; the endpoint now prefers those.

2. **The repoint guard didn't work**: NOT EXISTS doesn't reliably observe the same statement's earlier CREATEs, so re-pointing produced parallel duplicate relationships (38,945 groups in prod, collapsed manually). The script now repoints unconditionally and collapses parallel identical rels in a dedicated pass; distinct terms survive because they're distinct property maps.