### PR TITLE
chore: update profile-count claims to 48,000+

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A production-grade, open-source PEP (Politically Exposed Persons) database cover
 
 ## Why AfricaPEP?
 
-- **34,000+ verified PEP profiles** — Sourced from Wikidata's community-maintained, referenced database
+- **48,000+ verified PEP profiles** — Sourced from Wikidata's community-maintained, referenced database
 - **Complete African coverage** — All 54 AU member states
 - **Free and open source** — No licensing fees, no API quotas, no vendor lock-in
 - **Graph-powered** — Neo4j captures PEP relationships, family ties, and political networks
@@ -51,7 +51,7 @@ Wikidata is currently the sole data source, queried through one parameterized SP
 +-------------------------------------------------------------+
 |                        DATA SOURCE                          |
 |              Wikidata SPARQL Endpoint                       |
-|    Community-verified | Referenced | 34,000+ African PEPs  |
+|    Community-verified | Referenced | 48,000+ African PEPs  |
 +-------------------------------------------------------------+
                              |
                              v

--- a/africapep/api/main.py
+++ b/africapep/api/main.py
@@ -39,7 +39,7 @@ app = FastAPI(
         "Built from scratch using web scrapers, NLP pipelines, and entity resolution — "
         "no third-party PEP data providers.\n\n"
         "### Key Features\n"
-        "- **Name Screening** — Fuzzy match names against 34,000+ PEP profiles\n"
+        "- **Name Screening** — Fuzzy match names against 48,000+ PEP profiles\n"
         "- **Batch Screening** — Screen up to 50 names in a single request\n"
         "- **Full-text Search** — Search by name, country, tier, and active status\n"
         "- **FATF-aligned Tiers** — Tier 1 (heads of state), Tier 2 (MPs/judges), Tier 3 (local officials)\n"


### PR DESCRIPTION
The #57 catchment fixes applied to all 54 countries grew the database from 34,745 to 48,377 profiles (+39%). Full duplicate verification passed: zero duplicate positions, organisations, identical parallel relationships, and same-id persons. The dynamic README badge already shows the live number; this aligns the prose and OpenAPI description.